### PR TITLE
fix: TAMP_UPSTREAM path prefix is stripped when resolving upstream URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,13 +116,13 @@ return http.createServer(async (req, res) => {
 
   if (!provider) {
     if (config.log) console.error(`[tamp] ${req.method} ${req.url}`)
-    const upstreamUrl = new URL(req.url, config.upstream)
+    const upstreamUrl = new URL(config.upstream + req.url)
     return pipeRequest(req, res, upstreamUrl)
   }
 
   const upstream = config.upstreams?.[provider.name] || config.upstream
   const reqUrl = provider.normalizeUrl ? provider.normalizeUrl(req.url) : req.url
-  const upstreamUrl = new URL(reqUrl, upstream)
+  const upstreamUrl = new URL(upstream + reqUrl)
 
   const chunks = []
   let size = 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sliday/tamp",
-  "version": "0.3.0",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sliday/tamp",
-      "version": "0.3.0",
+      "version": "0.3.9",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",


### PR DESCRIPTION
## Problem

When `TAMP_UPSTREAM` is set to a URL with a non-root path (e.g. an API gateway at `https://proxy.example.com/api/anthropic`), the path prefix is silently dropped.

**Root cause:** `new URL('/v1/messages', 'https://proxy.example.com/api/anthropic')` resolves to `https://proxy.example.com/v1/messages` — the upstream path is replaced, not appended. This is standard `URL` constructor behavior when the second argument has a path and the first is an absolute path.

This means:
```
TAMP_UPSTREAM=https://proxy.example.com/api/anthropic
```
Requests go to `https://proxy.example.com/v1/messages` (404) instead of `https://proxy.example.com/api/anthropic/v1/messages`.

The bug is invisible when using `api.anthropic.com` as upstream (default) because it has no path prefix.

## Fix

Replace `new URL(reqUrl, upstream)` with `new URL(upstream + reqUrl)` in both URL resolution sites in `index.js`. String concatenation correctly appends the request path to the upstream base URL.

## Testing

All 213 existing tests pass. Verified manually with a fake upstream:
- `TAMP_UPSTREAM=http://127.0.0.1:18899/prefix` → request arrives at `/prefix/v1/messages` ✓