### PR TITLE
docs: document LLMLingua sidecar setup, ship sidecar/ in npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ Auto-detects API format, compresses tool output, forwards upstream. Error result
 
 Opt-in stages: `strip-comments`, `textpress` (LLM semantic compression), `graph` (session-scoped dedup — works on any coding agent: Codex, Claude Code, Aider — anywhere the same file is read twice, up to -99% per repeat block)
 
+### LLMLingua sidecar
+
+The `llmlingua` stage is enabled by default but requires a Python sidecar running on port 8788.
+
+Tamp auto-starts the sidecar when [`uv`](https://docs.astral.sh/uv/) is installed. Manual starts for all other cases:
+
+```bash
+uv run --with fastapi --with uvicorn --with llmlingua \
+  uvicorn server:app --host 127.0.0.1 --port 8788 \
+  --app-dir "$(npm root -g)/@sliday/tamp/sidecar"
+
+curl -s http://localhost:8788/health # Verify: {"status":"ok","model_loaded":true}
+
+tamp stop && tamp -y # restart Tamp, health endpoint will show `sidecar: ok`
+```
+
 ## Quick Start
 
 ```bash
@@ -180,7 +196,7 @@ Supported on all providers: Anthropic, OpenAI Chat, OpenAI Responses (Codex), Ge
 | `TAMP_MIN_SIZE` | `200` | Min content size (chars) |
 | `TAMP_LOG` | `true` | Enable logging |
 | `TAMP_CACHE_SAFE` | `true` | Compress newest only (prompt-cache safe) |
-| `TAMP_LLMLINGUA_URL` | *(none)* | LLMLingua sidecar URL |
+| `TAMP_LLMLINGUA_URL` | *(none)* | LLMLingua sidecar URL. Set to `http://localhost:8788` to skip the auto-probe (avoids startup race if sidecar is still loading the model) |
 
 **Recommended setups:**
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "providers.js",
     "session-graph.js",
     "stats.js",
-    "lib/"
+    "lib/",
+    "sidecar/"
   ],
   "version": "0.5.10",
   "description": "Token compression proxy for coding agents. Works with Claude Code, Aider, Cursor, Cline, Windsurf. 60-70% combined input+output savings with Caveman-integrated presets.",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "session-graph.js",
     "stats.js",
     "lib/",
-    "sidecar/"
+    "sidecar/server.py",
+    "sidecar/requirements.txt"
   ],
   "version": "0.5.10",
   "description": "Token compression proxy for coding agents. Works with Claude Code, Aider, Cursor, Cline, Windsurf. 60-70% combined input+output savings with Caveman-integrated presets.",


### PR DESCRIPTION
The llmlingua stage is enabled by default, but silently no-ops without the Python sidecar.

I had to do some debug steps too figure why this is the case, and I'd imagine other people would be interested in having this setup and working out of the box. LLMLingua has 20x token compression with minimal performance loss is pretty big ([Jiang et al](arxiv.org/abs/2310.05736)). I use a Mac though, not sure if the issue is specific to me

This adds setup instructions and ships `sidecar/` in the npm package, so npm installs have the files needed. Also documents `TAMP_LLMLINGUA_URL` env var to work around the startup race condition when the sidecar is still loading the model.