### PR TITLE
docs: add Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,10 @@ npm test
 node smoke.js
 ```
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=sliday/tamp&type=Date)](https://star-history.com/#sliday/tamp&Date)
+
 ## License
 
 MIT © [Stas Kulesh](https://sliday.com)


### PR DESCRIPTION
Adds a Star History chart to the README, just above License.

```markdown
[![Star History Chart](https://api.star-history.com/svg?repos=sliday/tamp&type=Date)](https://star-history.com/#sliday/tamp&Date)
```

Opened as a PR since direct pushes to main are gated.