### PR TITLE
chore: scaffold harn harness + README Security section

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,40 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 scripts/harness/security_guard.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/harness/trace_logger.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/harness/quality_gate.sh",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ video/*.mp4
 video/node_modules/
 bench/results/
 .playwright-mcp/
+.claude/settings.local.json
+.claude/agent-trace.jsonl
+CHECKPOINT.json
 *.png
 !site/favicon.ico
 !site/tamper-icon.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Agent North Star
+
+You are operating within a harnessed environment. Write maintainable, reliable code within architectural boundaries.
+
+## System of Record
+
+- Stack: Node.js (ESM, plain JavaScript — no TypeScript)
+- Entry points: `index.js` (proxy server), `bin/tamp.js` (CLI), `compress.js` (stage pipeline)
+- Tests: `npm test` (`node --test test/*.test.js`), plus `node smoke.js`
+
+## Constraints
+
+- Never push to main — create `feat/` or `fix/` branches and open a PR
+- New compression stages register in `metadata.js` and dispatch in `compress.js` — keep the 1–9 level ladder prefix-preserving
+- Secrets must never leave the machine: stages that call out (`llmlingua`, `textpress`) run after any redaction, never before
+- Keep diffs minimal — no unrelated reformatting or comment churn
+
+## Harness Hooks Active
+
+- **PreToolUse**: Security guard blocks dangerous shell commands
+- **PostToolUse**: Trace logger appends tool calls to `.claude/agent-trace.jsonl`
+- **Stop**: Quality gate runs `npm test` before completion
+
+## Workflow
+
+1. Understand → Read code, check LEARNED.md for gotchas
+2. Plan → Break task into steps
+3. Implement → Write code within constraints
+4. Verify → Run quality gate (`npm test`) before finishing
+5. Document → Update LEARNED.md if something was tricky
+
+## Context Budget
+
+- Keep this file under 60 lines — load skills on demand
+- Delegate research to sub-agents — only summaries return
+- After 30+ tool calls, compact and checkpoint
+
+## Escape Hatches
+
+- Quality gate stuck? Stop hook checks `stop_hook_active` — a retry lets you through
+- Security guard wrong? Report the false positive, use an alternative command
+- Same error 3 times? Stop and ask the human

--- a/README.md
+++ b/README.md
@@ -353,6 +353,14 @@ Where v0.8 actually pays off is **session-scoped work**, which is what coding ag
 
 The real win in v0.8 is **the level knob itself** — a zip-like 1–9 dial that lets you trade compression aggressiveness for risk without memorizing stage names. To reproduce the numbers above, run `node bench/runner.js --sweep` (set `OPENROUTER_API_KEY` for the live A/B pass).
 
+## Security
+
+Tamp runs on `localhost` and forwards to the upstream you configure. Most stages are local-only: `llmlingua` talks to a sidecar on `127.0.0.1`, `foundation-models` stays on-device. The one stage that sends content off-box is `textpress` (opt-in, level 7+), which posts to OpenRouter when `OPENROUTER_API_KEY` is set — leave it off if your tool output is sensitive.
+
+**Secret redaction** is on the roadmap ([#6](https://github.com/sliday/tamp/issues/6)): a `redact` stage that masks API keys, tokens, and `.env` values before anything leaves the machine, running ahead of every other stage. Until it lands, Tamp forwards file contents verbatim — treat your upstream's data policy as the boundary.
+
+This repo ships an agent harness (built with [harn.app](https://harn.app)): `AGENTS.md` plus PreToolUse / Stop hooks under `scripts/harness/` that block dangerous shell commands and gate completion on `npm test`. See `.claude/settings.json`.
+
 ## Development
 
 ```bash

--- a/scripts/harness/quality_gate.sh
+++ b/scripts/harness/quality_gate.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Stop hook — quality gate. Blocks agent from completing if code is broken.
+# Why: https://harn.app/kb/safety.html — "Quality checks in the loop"
+# Pattern: https://harn.app/kb/evals.html — "Infrastructure noise moves benchmarks"
+set -euo pipefail
+
+# Check dependencies
+command -v jq &>/dev/null || { echo "Harn: jq not found, quality gate skipped" >&2; exit 0; }
+
+PAYLOAD=$(cat /dev/stdin)
+IS_ACTIVE=$(echo "$PAYLOAD" | jq -r '.stop_hook_active // false' 2>/dev/null || echo "false")
+
+# CRITICAL: Break infinite loops
+if [ "$IS_ACTIVE" = "true" ]; then
+  exit 0
+fi
+
+# Session-aware temp file (prevents race conditions)
+LOG_FILE="${TMPDIR:-/tmp}/harn_gate_${PPID}_$$.log"
+
+echo "Harn: Running quality gate..." >&2
+
+# Detect stack and run checker (fail-closed: block if checker missing)
+if [ -f "tsconfig.json" ]; then
+  command -v npx &>/dev/null || {
+    echo "QUALITY GATE BLOCKED: TypeScript detected but 'npx' not found." >&2
+    echo "Install Node.js or remove tsconfig.json to skip." >&2
+    exit 2
+  }
+  npx tsc --noEmit > "$LOG_FILE" 2>&1 || {
+    echo "QUALITY GATE FAILED — TypeScript errors:" >&2
+    cat "$LOG_FILE" >&2
+    exit 2
+  }
+elif [ -f "package.json" ] && jq -e '.scripts.test' package.json &>/dev/null; then
+  command -v npm &>/dev/null || {
+    echo "QUALITY GATE BLOCKED: package.json test script found but 'npm' not found." >&2
+    exit 2
+  }
+  npm test > "$LOG_FILE" 2>&1 || {
+    echo "QUALITY GATE FAILED — test suite errors:" >&2
+    cat "$LOG_FILE" >&2
+    exit 2
+  }
+elif [ -f "Cargo.toml" ]; then
+  command -v cargo &>/dev/null || {
+    echo "QUALITY GATE BLOCKED: Rust detected but 'cargo' not found." >&2
+    exit 2
+  }
+  cargo check > "$LOG_FILE" 2>&1 || {
+    echo "QUALITY GATE FAILED — Rust errors:" >&2
+    cat "$LOG_FILE" >&2
+    exit 2
+  }
+elif [ -f "go.mod" ]; then
+  command -v go &>/dev/null || {
+    echo "QUALITY GATE BLOCKED: Go detected but 'go' not found." >&2
+    exit 2
+  }
+  go vet ./... > "$LOG_FILE" 2>&1 || {
+    echo "QUALITY GATE FAILED — Go errors:" >&2
+    cat "$LOG_FILE" >&2
+    exit 2
+  }
+elif [ -f "pyproject.toml" ] && command -v mypy &>/dev/null; then
+  mypy . > "$LOG_FILE" 2>&1 || {
+    echo "QUALITY GATE FAILED — Python type errors:" >&2
+    cat "$LOG_FILE" >&2
+    exit 2
+  }
+fi
+
+# Clean up temp file
+rm -f "$LOG_FILE"
+
+echo "Harn: Quality gate passed." >&2
+exit 0

--- a/scripts/harness/security_guard.py
+++ b/scripts/harness/security_guard.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""PreToolUse hook — blocks dangerous shell commands before execution.
+
+Why: https://harn.app/kb/safety.html — "Tools should be hard to misuse"
+Docs: https://harn.app/kb/safety.html — "Mitigating Prompt Injection Attacks"
+"""
+import sys
+import json
+import re
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    if not isinstance(payload, dict):
+        sys.exit(0)
+
+    if payload.get("tool_name") != "Bash":
+        sys.exit(0)
+
+    command = payload.get("parameters", {}).get("command", "")
+
+    dangerous = [
+        r"rm\s+-r[fF]",
+        r"git\s+push\s+.*main",
+        r"git\s+push\s+.*master",
+        r"chmod\s+777",
+        r">\s*~/",
+        r"curl\s+.*\|\s*(?:sudo\s+)?(?:bash|sh)",
+        r"sudo\s+rm",
+        r"mkfs\.",
+        r"dd\s+if=",
+    ]
+
+    for pattern in dangerous:
+        try:
+            if re.search(pattern, command):
+                print(f"HARNESS BLOCK: Matches prohibited pattern ({pattern}).", file=sys.stderr)
+                print("Find a safer alternative.", file=sys.stderr)
+                sys.exit(2)
+        except re.error:
+            print(f"HARNESS WARNING: Invalid pattern skipped: {pattern}", file=sys.stderr)
+            continue
+
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/harness/trace_logger.sh
+++ b/scripts/harness/trace_logger.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# PostToolUse hook — logs tool calls to JSONL for debugging and analytics.
+set -euo pipefail
+
+TRACE_FILE=".claude/agent-trace.jsonl"
+MAX_LINES=5000
+KEEP_LINES=2500
+
+# Ensure directory exists
+mkdir -p "$(dirname "$TRACE_FILE")"
+
+# Read payload from stdin
+PAYLOAD=$(cat /dev/stdin 2>/dev/null || echo "{}")
+
+# Extract tool_name and exit_code
+TOOL_NAME=$(echo "$PAYLOAD" | jq -r '.tool_name // "unknown"' 2>/dev/null || echo "unknown")
+EXIT_CODE=$(echo "$PAYLOAD" | jq -r '.exit_code // 0' 2>/dev/null || echo "0")
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Append trace entry
+echo "{\"ts\":\"$TIMESTAMP\",\"tool\":\"$TOOL_NAME\",\"exit\":$EXIT_CODE}" >> "$TRACE_FILE"
+
+# Log rotation: keep last KEEP_LINES when exceeding MAX_LINES
+if [ -f "$TRACE_FILE" ]; then
+  LINE_COUNT=$(wc -l < "$TRACE_FILE" | tr -d ' ')
+  if [ "$LINE_COUNT" -gt "$MAX_LINES" ]; then
+    tail -n "$KEEP_LINES" "$TRACE_FILE" > "${TRACE_FILE}.tmp" && mv "${TRACE_FILE}.tmp" "$TRACE_FILE"
+  fi
+fi
+
+exit 0


### PR DESCRIPTION
Lifts the repo's agent-readiness (harn.app CAR score) — it had none of the control surface before (no AGENTS.md, no hooks, no CI).

## What's added
- **AGENTS.md** — lean north-star: stack, entry points (`index.js`/`bin/tamp.js`/`compress.js`), constraints (no push to main, stages register in `metadata.js`, secrets never precede outbound stages).
- **scripts/harness/security_guard.py** — PreToolUse hook, blocks `rm -rf`, push-to-main, `curl|sh`, etc.
- **scripts/harness/quality_gate.sh** — Stop hook, runs `npm test` (loop-safe via `stop_hook_active`).
- **scripts/harness/trace_logger.sh** — PostToolUse JSONL trace with rotation.
- **.claude/settings.json** — wires the three hooks.
- **.gitignore** — ignores `settings.local.json`, `agent-trace.jsonl`, `CHECKPOINT.json`.
- **README Security section** — documents data boundaries (`textpress` is the only off-box stage), the secret-redaction roadmap (#6), and the harness.

## Verified
- Guard blocks `rm -rf` (exit 2), allows `ls` (exit 0).
- settings.json valid JSON; hooks wired.
- Quality gate detects the `npm test` script.
- Trace logger appends valid JSONL.
- Scripts committed mode 100755.

Built with [harn.app](https://harn.app).