### PR TITLE
fix(providers): handle array content in openai getLastUserText/injectOutputHint

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -296,7 +296,14 @@ const openai = {
     if (!body?.messages?.length) return null
     for (let i = body.messages.length - 1; i >= 0; i--) {
       const msg = body.messages[i]
-      if (msg?.role === 'user' && typeof msg.content === 'string') return msg.content
+      if (msg?.role !== 'user') continue
+      if (typeof msg.content === 'string') return msg.content
+      // OpenAI chat allows array content parts (vision, structured input).
+      if (Array.isArray(msg.content)) {
+        for (const b of msg.content) {
+          if (b?.type === 'text' && typeof b.text === 'string') return b.text
+        }
+      }
     }
     return null
   },
@@ -307,6 +314,17 @@ const openai = {
       if (msg?.role !== 'user') continue
       if (typeof msg.content === 'string') {
         msg.content = msg.content + '\n\n' + text
+        return true
+      }
+      if (Array.isArray(msg.content)) {
+        for (let j = msg.content.length - 1; j >= 0; j--) {
+          const b = msg.content[j]
+          if (b?.type === 'text' && typeof b.text === 'string') {
+            b.text = b.text + '\n\n' + text
+            return true
+          }
+        }
+        msg.content.push({ type: 'text', text })
         return true
       }
       return false

--- a/test/output-mode.test.js
+++ b/test/output-mode.test.js
@@ -61,6 +61,36 @@ describe('output-mode injection — provider injectOutputHint contracts', () => 
     assert.equal(body.messages[0].content, 'first')
   })
 
+  it('openai chat: appends to last text part in array content', () => {
+    const body = {
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'first part' },
+          { type: 'text', text: 'second part' },
+        ],
+      }],
+    }
+    const ok = openai.injectOutputHint(body, '[RULES]')
+    assert.equal(ok, true)
+    assert.equal(body.messages[0].content[1].text, 'second part\n\n[RULES]')
+    assert.equal(body.messages[0].content[0].text, 'first part', 'earlier text part must NOT be touched')
+  })
+
+  it('openai chat: pushes new text part when array has no text', () => {
+    const body = {
+      messages: [{
+        role: 'user',
+        content: [{ type: 'image_url', image_url: { url: 'data:...' } }],
+      }],
+    }
+    const ok = openai.injectOutputHint(body, '[RULES]')
+    assert.equal(ok, true)
+    assert.equal(body.messages[0].content.length, 2)
+    assert.equal(body.messages[0].content[1].type, 'text')
+    assert.equal(body.messages[0].content[1].text, '[RULES]')
+  })
+
   it('openai-responses: appends to last input_text in last user item', () => {
     const body = {
       input: [
@@ -130,6 +160,18 @@ describe('output-mode injection — getLastUserText contracts', () => {
       { role: 'user', content: [{ type: 'input_text', text: 'two' }] },
     ]}
     assert.equal(openaiResponses.getLastUserText(body), 'two')
+  })
+
+  it('openai chat: returns first text part from array content', () => {
+    const body = { messages: [
+      { role: 'user', content: 'first' },
+      { role: 'tool', tool_call_id: 't', content: 'result' },
+      { role: 'user', content: [
+        { type: 'image_url', image_url: { url: 'data:...' } },
+        { type: 'text', text: 'real prompt' },
+      ] },
+    ]}
+    assert.equal(openai.getLastUserText(body), 'real prompt')
   })
 
   it('gemini: returns last user text part', () => {


### PR DESCRIPTION
## Problem
The OpenAI Chat Completions API allows a user message `content` to be either a string **or an array of content parts** (`[{type:'text',text:...}, {type:'image_url',...}]`). Array form is common with vision requests and several clients that always emit structured content.

The `openai` provider adapter only handled the string case:
- `getLastUserText` returned `null` for array content.
- `injectOutputHint` returned `false` for array content.

Result: tamp's output-mode rules hint was **silently dropped** for OpenAI / Kimi / Moonshot clients sending array content. The `anthropic` and `openai-responses` adapters already handle arrays, so `openai` was the lone gap. Branches considered: skip (status quo, keeps the silent degradation) vs. mirror the existing array handling (chosen).

## Solution
Mirror the `anthropic` / `openai-responses` handling in the `openai` adapter:
- `getLastUserText`: read the first `{type:'text'}` part from array content.
- `injectOutputHint`: append to the **last** text part, or push a new `{type:'text',text}` when none exists — still targeting only the latest user turn, so cache safety is preserved.

`kimi` and `moonshot` alias these methods by reference and inherit the fix automatically. The string path is unchanged. `{type:'text',text}` is valid OpenAI wire format, so no protocol contract is broken.

TDD: 3 failing tests added first (`test/output-mode.test.js`), then the implementation.

## Context / impact
- Restores the output-mode token-saving hint for OpenAI-compatible agents using structured content (e.g. Codex, vision-enabled clients).
- One behavior shift: `getLastUserText` now prefers the latest user turn's array text over reaching back to an older string turn — more correct, no realistic regression.
- Tests: full suite 525/525 pass (was 522, +3 new). No build/lint scripts in this repo.