### PR TITLE
release: v0.8.1 (provider array-content + duplicate ref rehydration fixes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sidecar/server.py",
     "sidecar/requirements.txt"
   ],
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Token compression proxy for coding agents. Works with Claude Code, Aider, Cursor, Cline, Windsurf. 60-70% combined input+output savings with Caveman-integrated presets and per-command rewriters.",
   "type": "module",
   "main": "index.js",

--- a/providers.js
+++ b/providers.js
@@ -184,12 +184,20 @@ function applyAnthropicRehydration(body, refs) {
     if (typeof current !== 'string') continue
 
     let updated = current
+    const seenMatch = new Set()
     for (const ref of items) {
+      if (seenMatch.has(ref.match)) continue
+      seenMatch.add(ref.match)
       const expandedSentinel = `<tamp-ref:v1:${ref.hash} expanded -`
-      if (updated.indexOf(expandedSentinel) !== -1) continue
-      const idx = updated.indexOf(ref.match)
-      if (idx === -1) continue
-      updated = updated.slice(0, idx) + ref.expansion + updated.slice(idx + ref.match.length)
+      // Idempotency across passes: skip if the INCOMING body already carried
+      // this expansion. Check `current` (the original), not `updated`, so an
+      // expansion we insert this pass cannot suppress a sibling marker that
+      // shares the same hash.
+      if (current.indexOf(expandedSentinel) !== -1) continue
+      if (current.indexOf(ref.match) === -1) continue
+      // Replace every occurrence: the model may quote the same marker more
+      // than once in one block.
+      updated = updated.split(ref.match).join(ref.expansion)
     }
 
     if (updated === current) continue

--- a/site/index.html
+++ b/site/index.html
@@ -470,8 +470,8 @@
      ============================================================ -->
 <section class="hero-section" id="hero">
     <div class="hero-inner">
-        <a href="#levels" class="release-chip" aria-label="What's new in v0.8.0">
-            <span class="release-chip__tag">v0.8.0</span>
+        <a href="#levels" class="release-chip" aria-label="What's new in v0.8.1">
+            <span class="release-chip__tag">v0.8.1</span>
             <span class="release-chip__text">zip-like 1–9 compression levels + Codex ChatGPT + Kimi CLI support</span>
             <span class="release-chip__arrow">&rarr;</span>
         </a>

--- a/test/disclosure.test.js
+++ b/test/disclosure.test.js
@@ -187,6 +187,41 @@ describe('rehydrateReferences - cache hit injects full body', () => {
   })
 })
 
+describe('rehydrateReferences - same marker quoted twice in one block', () => {
+  const dir = freshDir('dup')
+  after(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('expands every occurrence of a repeated marker, leaving no raw marker behind', () => {
+    const cache = createBrCache({ cacheDir: dir, minSize: 1024 })
+    const fullText = bigBody('DUP', 64 * 1024)
+    const put = cache.put(fullText)
+    assert.ok(put)
+    const bytes = Buffer.byteLength(fullText, 'utf8')
+    const marker = `<tamp-ref:v1:${put.hash}:${bytes}>`
+    const body = {
+      model: 'claude-3-5-sonnet-20241022',
+      max_tokens: 1024,
+      messages: [
+        { role: 'user', content: 'Please compress this file.' },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: `Compare the start of ${marker} with the end of ${marker}.` },
+          ],
+        },
+      ],
+    }
+
+    const result = rehydrateReferences(body, anthropic, cache)
+    assert.equal(result.rehydrated, 2, 'both quoted markers should count as rehydrated')
+
+    const updated = body.messages[1].content[0].text
+    assert.ok(!updated.includes(marker), 'no raw <tamp-ref:...:BYTES> marker may remain after rehydration')
+    const headerCount = updated.split(`<tamp-ref:v1:${put.hash} expanded -`).length - 1
+    assert.equal(headerCount, 2, 'both markers must be expanded into full blocks')
+  })
+})
+
 describe('compressRequest - two-turn disclosure + rehydration pipeline', () => {
   const dir = freshDir('pipeline')
   after(() => rmSync(dir, { recursive: true, force: true }))


### PR DESCRIPTION
## Problem
Two correctness bugs shipped in 0.8.0, and the npm package + landing page need to reflect the patch.

1. `applyAnthropicRehydration` expanded only the **first** occurrence when the model quoted the same `<tamp-ref:v1:HASH:BYTES>` marker twice in one block — the in-loop idempotency guard tripped on the expansion it had just inserted, leaving raw markers the upstream model sees as garbage. (commit `1bfcc82`)
2. (already merged in #11) the OpenAI adapter dropped the output-mode hint for array `content`.

## Solution
- **disclosure fix**: check the original `current` string for the idempotency sentinel (cross-pass double-expansion still prevented), dedup refs by `match`, replace all occurrences via `split/join`. Failing-first test added in `test/disclosure.test.js`.
- **release**: bump `package.json` 0.8.0 → 0.8.1; update the landing-page release chip to `v0.8.1`. npm version badges auto-update from the registry.

## Context / impact
- Full suite: 526/526 pass.
- Merging triggers the Cloudflare Pages auto-deploy of the landing page.
- npm publish of 0.8.1 follows separately (after auth).
- No public API / env var / CLI changes.