### PR TITLE
fix(br-cache): don't report success for a payload prune immediately evicts

### DIFF
--- a/lib/br-cache.js
+++ b/lib/br-cache.js
@@ -123,6 +123,10 @@ export function createBrCache({ cacheDir = defaultCacheDir(), maxBytes = DEFAULT
     }
 
     pruneInternal()
+    // If this entry alone exceeds maxBytes, pruneInternal() just evicted it.
+    // Don't claim persistence we can't honour — a phantom record would leave
+    // the caller with a brHash that get() can never resolve.
+    if (!existsSync(finalPath)) return null
     return { hash, storedBytes: byteLen, brotliBytes }
   }
 

--- a/test/br-cache.test.js
+++ b/test/br-cache.test.js
@@ -123,6 +123,24 @@ describe('br-cache — eviction', () => {
   })
 })
 
+describe('br-cache — single payload larger than the whole budget', () => {
+  const dir = freshDir('oversized')
+  after(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('put() returns null when one entry alone exceeds maxBytes (no phantom record)', () => {
+    const cache = createBrCache({ cacheDir: dir, minSize: 1024, maxBytes: 4 * 1024 })
+    // ~64 KB of incompressible data: the brotli output far exceeds the 4 KB
+    // budget, so pruneInternal() evicts it immediately after the write.
+    const text = `seed-${incompressible(64 * 1024)}`
+    const put = cache.put(text)
+    // Contract: if put() returns a record, the content MUST be retrievable.
+    // Claiming success for content it just evicted creates a phantom brHash
+    // that get() can never resolve.
+    assert.equal(put, null, 'put must not claim success for content it immediately evicts')
+    assert.equal(cache.stats().entries, 0, 'no entry should remain on disk')
+  })
+})
+
 describe('br-cache — decompression failure is a miss', () => {
   const dir = freshDir('corrupt')
   after(() => rmSync(dir, { recursive: true, force: true }))


### PR DESCRIPTION
## Problem
`br-cache.js` `put()` wrote the file, ran `pruneInternal()`, then returned a success record `{ hash, storedBytes, brotliBytes }` **unconditionally**. When a single compressed payload alone exceeds `maxBytes`, prune evicts it right after the write (its atime is newest, so it survives only if it fits the budget). `put()` still claimed success, leaving the caller (session-graph offload, disclosure) with a `brHash` that `get()` can never resolve, and inflating `offloaded`/`brotliBytes` counters.

Found via a parallel module audit; verified by repro. Med severity, low real-world likelihood at the 512 MB default `maxBytes`, but a live bug under a tightened `maxBytes` config.

## Solution
After `pruneInternal()`, return `null` if the just-written entry was evicted (`!existsSync(finalPath)`). Honors the contract: a record means the content is retrievable.

Both callers already guard a null result (`session-graph.js:86`, `compress.js:134`), so on the new null path the target simply stays uncompressed — the safe fallback, no phantom marker, no data loss.

## Context / impact
- TDD: failing-first test (single payload larger than the whole budget), then fix.
- Full suite 527/527 pass; existing eviction test still green (newest file survives prune unless it alone exceeds the budget).
- No version bump / publish — rides with the next release batch.
- No public API / env var / CLI changes.