### PR TITLE
release: v0.8.4 — rewriter, dedup, and backup correctness fixes

### DIFF
--- a/compress.js
+++ b/compress.js
@@ -37,8 +37,11 @@ function deduplicateTargets(targets) {
     const prev = seen.get(key)
     if (prev && prev.text === target.text) {
       const ref = `[see tool_result in message ${prev.path[1]}, block ${prev.index} — identical content]`
-      target.compressed = ref
-      target.dedup = true
+      // Never expand: a tiny duplicate can be shorter than the reference itself.
+      if (ref.length < target.text.length) {
+        target.compressed = ref
+        target.dedup = true
+      }
     } else {
       seen.set(key, target)
     }

--- a/lib/compress-file.js
+++ b/lib/compress-file.js
@@ -144,9 +144,11 @@ export async function compressFile(filePath, options = {}) {
     }
   }
 
-  // Create backup
+  // Create backup. Never clobber an existing backup — it holds the pristine
+  // original from a prior run, and overwriting it with already-compressed
+  // content would make the original unrecoverable.
   const backupPath = filePath + '.bak'
-  if (!options.noBackup) {
+  if (!options.noBackup && !existsSync(backupPath)) {
     try {
       await copyFile(filePath, backupPath)
     } catch (error) {

--- a/lib/rewriters/commands/docker.js
+++ b/lib/rewriters/commands/docker.js
@@ -34,7 +34,9 @@ export default {
       if (LEGACY_PROGRESS.test(line)) continue;
       // BuildKit "in-progress" duplicated step lines end with a fractional second
       // marker and are re-emitted as DONE later; strip the non-DONE variants.
-      if (/^#\d+\s+\S.*\s\d+\.\d+s$/.test(line) && !/\sDONE\b/.test(line)) continue;
+      // Never strip a line carrying error/warning/failure context — a RUN step's
+      // stdout can legitimately end in a duration (e.g. "build failed in 2.3s").
+      if (/^#\d+\s+\S.*\s\d+\.\d+s$/.test(line) && !/\sDONE\b/.test(line) && !/\b(error|warning|fail)/i.test(line)) continue;
       out.push(line);
     }
 

--- a/lib/rewriters/commands/jest.js
+++ b/lib/rewriters/commands/jest.js
@@ -6,7 +6,9 @@
 // the Tests/Suites/Time/Snapshots summary and any stack traces.
 
 const PASS_LINE = /^\s*PASS\s+\S+/;
-const FAIL_LINE = /^\s*FAIL\s+\S+/;
+// `m` flag is required: the all-pass gate scans the whole multi-line output,
+// and a FAIL line is rarely the first line (jest interleaves PASS suites).
+const FAIL_LINE = /^\s*FAIL\s+\S+/m;
 const JEST_SIG = /(^|\n)(PASS\s+\S+|FAIL\s+\S+|Tests:\s+.*\d+\s+(passed|failed|total)|Test Suites:\s+\d)/;
 
 export default {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sidecar/server.py",
     "sidecar/requirements.txt"
   ],
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Token compression proxy for coding agents. Works with Claude Code, Aider, Cursor, Cline, Windsurf. 60-70% combined input+output savings with Caveman-integrated presets and per-command rewriters.",
   "type": "module",
   "main": "index.js",

--- a/site/index.html
+++ b/site/index.html
@@ -470,8 +470,8 @@
      ============================================================ -->
 <section class="hero-section" id="hero">
     <div class="hero-inner">
-        <a href="#levels" class="release-chip" aria-label="What's new in v0.8.1">
-            <span class="release-chip__tag">v0.8.1</span>
+        <a href="#levels" class="release-chip" aria-label="What's new in v0.8.4">
+            <span class="release-chip__tag">v0.8.4</span>
             <span class="release-chip__text">zip-like 1–9 compression levels + Codex ChatGPT + Kimi CLI support</span>
             <span class="release-chip__arrow">&rarr;</span>
         </a>

--- a/test/compress-file.test.js
+++ b/test/compress-file.test.js
@@ -106,6 +106,35 @@ describe('compressFile', () => {
     await fs.unlink(result.backup)
   })
 
+  it('does not overwrite an existing backup on re-run (preserves the pristine original)', async () => {
+    const testDir = tmpdir()
+    const f = join(testDir, 'test-rerun-backup.json')
+    const pretty = JSON.stringify({
+      name: 'tamp',
+      version: '0.8.3',
+      keywords: ['claude', 'anthropic', 'proxy', 'compression', 'tokens', 'llm'],
+      scripts: { start: 'node bin/tamp.js', test: 'node --test test/*.test.js' },
+    }, null, 2)
+    await writeFile(f, pretty, 'utf8')
+    // Simulate a prior run's pristine backup.
+    const bak = f + '.bak'
+    await writeFile(bak, 'PRISTINE ORIGINAL CONTENT', 'utf8')
+
+    const result = await compressFile(f, { dryRun: false })
+    assert(result.success)
+
+    const after = await readFile(bak, 'utf8')
+    assert.strictEqual(
+      after,
+      'PRISTINE ORIGINAL CONTENT',
+      'an existing backup must be preserved — re-running compress must not clobber the original'
+    )
+
+    const fs = await import('node:fs/promises')
+    await fs.unlink(f)
+    await fs.unlink(bak)
+  })
+
   it('returns dry run result without writing file', async () => {
     const testDir = tmpdir()
     testFile = join(testDir, 'test-dryrun.md')

--- a/test/compress.test.js
+++ b/test/compress.test.js
@@ -267,6 +267,41 @@ describe('compressRequest with OpenAI format', () => {
   })
 })
 
+describe('compressRequest dedup stage — never expand', () => {
+  const dedupConfig = { minSize: 1, stages: ['dedup'], llmLinguaUrl: null, cacheSafe: false }
+
+  it('does not replace a tiny duplicate with a longer reference', async () => {
+    const body = {
+      messages: [
+        { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'done' }] },
+        { role: 'assistant', content: 'ok' },
+        { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't2', content: 'done' }] },
+      ],
+    }
+    const { body: out } = await compressMessages(body, dedupConfig)
+    assert.equal(
+      out.messages[2].content[0].content,
+      'done',
+      'a tiny duplicate must stay verbatim — the dedup reference is longer than the original'
+    )
+  })
+
+  it('still deduplicates a large duplicate (reference is shorter)', async () => {
+    const big = 'identical line of output\n'.repeat(50) // ~1.25 KB, far longer than the ref
+    const body = {
+      messages: [
+        { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: big }] },
+        { role: 'assistant', content: 'ok' },
+        { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't2', content: big }] },
+      ],
+    }
+    const { body: out } = await compressMessages(body, dedupConfig)
+    const second = out.messages[2].content[0].content
+    assert.ok(second.includes('identical content'), 'large duplicate should be replaced by a reference')
+    assert.ok(second.length < big.length, 'dedup reference must be shorter than the original')
+  })
+})
+
 describe('compressRequest with graph stage (session-scoped dedup)', () => {
   const largeOutput = JSON.stringify({ file: 'providers.js', content: 'x'.repeat(2000) })
 

--- a/test/rewriters.test.js
+++ b/test/rewriters.test.js
@@ -186,3 +186,34 @@ describe('detectCommandOutput', () => {
     assert.equal(detectCommandOutput(42), null)
   })
 })
+
+describe('rewriters — never strip failure/error context', () => {
+  it('docker: keeps a RUN-step error line that ends in a duration', () => {
+    const input = [
+      '#5 [2/7] RUN apt-get update 0.3s',          // benign in-progress heading — should be stripped
+      '#8 [5/7] RUN make',
+      '#8 45.2 make: *** [all] build failed in 2.3s', // real error ending in a duration — must be kept
+      '#8 DONE 50.1s',
+    ].join('\n')
+    const { text, rewriter } = rewriteCommandOutput(input)
+    assert.equal(rewriter, 'docker')
+    assert.ok(text.includes('build failed in 2.3s'), 'error line ending in a duration must be preserved')
+    assert.ok(!text.includes('apt-get update 0.3s'), 'benign in-progress heading should still be stripped')
+  })
+
+  it('jest: does not strip PASS lines when a non-first FAIL line is present', () => {
+    const input = [
+      'PASS src/a.test.ts',
+      'FAIL src/b.test.ts',
+      '  ● Test suite failed to run',
+      '    Cannot find module \'./missing\'',
+      'Test Suites: 1 failed, 1 passed, 2 total',
+      'Tests:       3 passed, 3 total',
+    ].join('\n')
+    const { text, rewriter } = rewriteCommandOutput(input)
+    assert.equal(rewriter, 'jest')
+    // The run failed (a suite failed to compile), so the all-pass gate must not
+    // fire — PASS lines stay, preserving full context.
+    assert.equal(text, input, 'a failing run must pass through untouched')
+  })
+})


### PR DESCRIPTION
## Problem
Three independent correctness/reliability bugs accumulated since 0.8.3, each preserving tamp's promise (reduce tokens without changing meaning or losing data):

1. **Rewriters dropped failure context.** `docker` stripped any BuildKit step line ending in a duration (including a RUN step's own error stdout); `jest`'s all-pass gate used a non-`m` `FAIL_LINE` regex, so a non-first FAIL line misfired the gate and stripped PASS lines from a failing run.
2. **Dedup could expand the payload.** `deduplicateTargets` replaced identical tool_results with a ~55-char reference even when the original was shorter, growing tiny duplicates and logging negative savings.
3. **`tamp compress-config` could destroy the original.** A second run copied the already-compressed file over `<file>.bak`, making the pristine original unrecoverable.

## Solution
- docker: never strip a line matching `/error|warning|fail/i`. jest: add the `m` flag to `FAIL_LINE`.
- dedup: substitute only when the reference is strictly shorter than the original.
- compress-file: create the backup only when `<file>.bak` doesn't already exist.

All three are additive/narrowing guards — no happy-path behavior change.

## Context / impact
- Full suite: 547/547 (542 base + 5 new failing-first tests).
- Bumps `package.json` 0.8.3 → 0.8.4 and the landing-page release chip (was stale at v0.8.1).
- Merging triggers the Cloudflare Pages deploy; npm publish of 0.8.4 follows.
- No public API / env var / CLI changes.

Each fix landed TDD (failing test first). Found via parallel module audits across the iteration loop.