### PR TITLE
release: v0.8.6 — json valid-output fix + multi-provider upstream docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,11 @@ Supported on all providers: Anthropic, OpenAI Chat, OpenAI Responses (Codex), Ge
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TAMP_PORT` | `7778` | Listen port |
-| `TAMP_UPSTREAM` | `https://api.anthropic.com` | Default upstream |
+| `TAMP_UPSTREAM` | `https://api.anthropic.com` | Anthropic (default) upstream |
+| `TAMP_UPSTREAM_OPENAI` | `https://api.openai.com` | Upstream for OpenAI-compatible routes (`/v1/chat/completions`, `/v1/responses`) |
+| `TAMP_UPSTREAM_GEMINI` | `https://generativelanguage.googleapis.com` | Upstream for Gemini (`generateContent`) routes |
+| `TAMP_UPSTREAM_KIMI` | `https://api.kimi.com` | Upstream for Kimi Code routes |
+| `TAMP_UPSTREAM_MOONSHOT` | `https://api.moonshot.cn` | Upstream for Moonshot OpenAI-compatible routes |
 | `TAMP_MIN_SIZE` | `200` | Min content size (chars) |
 | `TAMP_LOG` | `true` | Enable logging |
 | `TAMP_CACHE_SAFE` | `true` | Compress newest only (prompt-cache safe) |

--- a/lib/compress-file.js
+++ b/lib/compress-file.js
@@ -23,7 +23,11 @@ const STRATEGIES = Object.freeze({
     minSize: 200,
   },
   json: {
-    stages: ['minify', 'toon', 'prune'],
+    // No 'toon' here: this strategy rewrites a file in place that keeps its
+    // .json extension, so the output must stay valid JSON. TOON is not JSON.
+    // minify (lossless) and prune (documented npm-metadata strip) keep it
+    // parseable.
+    stages: ['minify', 'prune'],
     preserveStructure: false,
     minSize: 100,
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sidecar/server.py",
     "sidecar/requirements.txt"
   ],
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Token compression proxy for coding agents. Works with Claude Code, Aider, Cursor, Cline, Windsurf. 60-70% combined input+output savings with Caveman-integrated presets and per-command rewriters.",
   "type": "module",
   "main": "index.js",

--- a/site/index.html
+++ b/site/index.html
@@ -470,8 +470,8 @@
      ============================================================ -->
 <section class="hero-section" id="hero">
     <div class="hero-inner">
-        <a href="#levels" class="release-chip" aria-label="What's new in v0.8.4">
-            <span class="release-chip__tag">v0.8.4</span>
+        <a href="#levels" class="release-chip" aria-label="What's new in v0.8.6">
+            <span class="release-chip__tag">v0.8.6</span>
             <span class="release-chip__text">zip-like 1–9 compression levels + Codex ChatGPT + Kimi CLI support</span>
             <span class="release-chip__arrow">&rarr;</span>
         </a>

--- a/test/compress-file.test.js
+++ b/test/compress-file.test.js
@@ -76,6 +76,27 @@ describe('compressContent', () => {
     assert(jsonResult.success || jsonResult.skipped)
     assert(textResult.success || textResult.skipped)
   })
+
+  it('json strategy output stays valid JSON (a .json file must not become TOON)', async () => {
+    // Tabular data where TOON encoding would otherwise win on size.
+    const content = JSON.stringify([
+      { id: 1, name: 'Alice', email: 'alice@example.com', role: 'admin' },
+      { id: 2, name: 'Bob', email: 'bob@example.com', role: 'user' },
+      { id: 3, name: 'Charlie', email: 'charlie@example.com', role: 'user' },
+      { id: 4, name: 'Diana', email: 'diana@example.com', role: 'admin' },
+    ], null, 2)
+    const result = await compressContent(content, 'json', { log: false })
+    assert(result.success, 'tabular JSON should compress')
+    assert.doesNotThrow(
+      () => JSON.parse(result.compressed),
+      'json-strategy output must remain parseable JSON — the file keeps its .json extension'
+    )
+    assert.deepStrictEqual(
+      JSON.parse(result.compressed),
+      JSON.parse(content),
+      'minified JSON must preserve the original data'
+    )
+  })
 })
 
 describe('compressFile', () => {


### PR DESCRIPTION
## Problem
Two improvements queued since 0.8.5:

1. **`tamp compress-config <file>.json` could emit invalid JSON.** The `json` file strategy included the `toon` stage; for tabular JSON, TOON wins on size and the file (which keeps its `.json` extension) is rewritten as TOON — not parseable JSON, breaking any consumer. A syntactic protocol-contract violation.
2. **Undocumented multi-provider upstream overrides.** The README sells multi-provider routing but the env-var table only listed `TAMP_UPSTREAM` (Anthropic), leaving no documented way to point a route at a non-default endpoint (Azure, self-hosted gateway, regional mirror).

## Solution
1. Drop `toon` from the `json` file strategy → `['minify', 'prune']`. Output stays valid JSON; minify (lossless) + prune (documented npm-metadata strip) both preserve parseability. The proxy path is unaffected (uses level-based stages; `toon` remains available there). Failing-first test added.
2. Document `TAMP_UPSTREAM_OPENAI/GEMINI/KIMI/MOONSHOT` with their exact `config.js` defaults.

## Context / impact
- Full suite: 560/560 (559 base + 1 new test).
- Bumps `package.json` 0.8.5 → 0.8.6 and the landing chip (was stale at v0.8.4).
- Merging triggers the Cloudflare Pages deploy; npm publish of 0.8.6 follows.
- No public API / env var / CLI changes.