### PR TITLE
release: v0.8.7 — session-key/prune/cache correctness + fidelity guardrails

### DIFF
--- a/compress.js
+++ b/compress.js
@@ -180,11 +180,20 @@ function bm25TrimTargets(targets, body, provider) {
 }
 
 // --- Stage: prune ---
-const PRUNE_KEYS = new Set(['integrity', 'shasum', '_id', '_from', '_resolved', '_integrity', '_nodeVersion', '_npmVersion', '_phantomChildren', '_requiredBy'])
+// Unambiguously npm-internal keys — safe to drop regardless of value.
+const PRUNE_KEYS = new Set(['_id', '_from', '_resolved', '_integrity', '_nodeVersion', '_npmVersion', '_phantomChildren', '_requiredBy'])
+// `integrity` / `shasum` are common field names; only drop them when the value
+// is actually an npm hash, so a legitimately-named field (e.g. integrity:"high")
+// in a non-npm tool_result is preserved.
+const NPM_INTEGRITY = /^sha\d{1,3}-[A-Za-z0-9+/]+={0,2}$/
+const NPM_SHASUM = /^[a-f0-9]{40}$/i
 
 function shouldPrune(key, val) {
   if (PRUNE_KEYS.has(key)) return true
-  if (key === 'resolved' && typeof val === 'string' && val.startsWith('https://registry.')) return true
+  if (typeof val !== 'string') return false
+  if (key === 'resolved' && val.startsWith('https://registry.')) return true
+  if (key === 'integrity' && NPM_INTEGRITY.test(val)) return true
+  if (key === 'shasum' && NPM_SHASUM.test(val)) return true
   return false
 }
 

--- a/index.js
+++ b/index.js
@@ -336,7 +336,7 @@ return http.createServer(async (req, res) => {
     const parsed = JSON.parse(textBody.toString('utf-8'))
 
     const sessionKey = (config.stages?.includes('graph') || config.stages?.includes('read-diff'))
-      ? deriveSessionKey(req.headers)
+      ? deriveSessionKey(req.headers, parsed)
       : null
     const sessionBucket = config.stages?.includes('graph') && sessionKey
       ? sessionStore.getBucket(sessionKey)

--- a/index.js
+++ b/index.js
@@ -406,7 +406,7 @@ function probeSidecar(config) {
   req.on('error', () => {
     sidecarAvailable = false
     console.error('[tamp] \u26a0 llmlingua stage enabled but sidecar not running \u2014 text blocks won\u2019t compress')
-    console.error('[tamp]   start with: uv run --with fastapi --with uvicorn --with llmlingua --with mlx uvicorn server:app --host 0.0.0.0 --port 8788 --app-dir sidecar')
+    console.error('[tamp]   start with: uv run --with fastapi --with uvicorn --with llmlingua --with mlx uvicorn server:app --host 127.0.0.1 --port 8788 --app-dir sidecar')
   })
   req.on('timeout', () => { req.destroy() })
 }

--- a/lib/br-cache.js
+++ b/lib/br-cache.js
@@ -39,7 +39,9 @@ function filePathFor(cacheDir, hash) {
 }
 
 export function createBrCache({ cacheDir = defaultCacheDir(), maxBytes = DEFAULT_MAX_BYTES, minSize = DEFAULT_MIN_SIZE } = {}) {
-  try { mkdirSync(cacheDir, { recursive: true }) } catch { /* ignore */ }
+  // 0o700: cached bodies are full tool_results (code, file contents, command
+  // output) that may contain secrets — keep them owner-only on shared machines.
+  try { mkdirSync(cacheDir, { recursive: true, mode: 0o700 }) } catch { /* ignore */ }
 
   let hits = 0
   let misses = 0
@@ -101,7 +103,7 @@ export function createBrCache({ cacheDir = defaultCacheDir(), maxBytes = DEFAULT
       } catch { /* fall through and rewrite */ }
     }
 
-    try { mkdirSync(shardDir, { recursive: true }) } catch { /* ignore */ }
+    try { mkdirSync(shardDir, { recursive: true, mode: 0o700 }) } catch { /* ignore */ }
 
     let compressed
     try {
@@ -114,7 +116,7 @@ export function createBrCache({ cacheDir = defaultCacheDir(), maxBytes = DEFAULT
 
     const tmpPath = `${finalPath}.tmp`
     try {
-      writeFileSync(tmpPath, compressed)
+      writeFileSync(tmpPath, compressed, { mode: 0o600 })
       renameSync(tmpPath, finalPath)
       brotliBytes = compressed.length
     } catch {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sidecar/server.py",
     "sidecar/requirements.txt"
   ],
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Token compression proxy for coding agents. Works with Claude Code, Aider, Cursor, Cline, Windsurf. 60-70% combined input+output savings with Caveman-integrated presets and per-command rewriters.",
   "type": "module",
   "main": "index.js",

--- a/session-graph.js
+++ b/session-graph.js
@@ -55,11 +55,35 @@ export function createSessionBucket({ brCache = null } = {}) {
   }
 }
 
-export function deriveSessionKey(headers) {
+// A conversation-stable fingerprint: the system prompt plus the first turn.
+// Claude Code (and peers) resend an immutable opening every turn, so this is
+// constant within a conversation but differs across conversations — even when
+// they share one API token. Empty when no body is available (callers that omit
+// it get the legacy token-only key).
+function conversationSeed(body) {
+  if (!body || typeof body !== 'object') return ''
+  const turns = body.messages || body.contents || body.input
+  const first = Array.isArray(turns) && turns.length ? turns[0] : null
+  if (first == null && body.system === undefined) return ''
+  try {
+    return JSON.stringify({ system: body.system ?? null, first }).slice(0, 4096)
+  } catch {
+    return ''
+  }
+}
+
+// Session key scopes the read-diff / graph caches. It MUST be conversation-
+// specific: keying on the token alone let content from one conversation be
+// referenced (read-diff, graph) in another that shares the token, emitting a
+// diff/marker against a base the second conversation's model never saw. A
+// too-unique seed merely disables cross-request dedup (full content is
+// forwarded) — the safe failure direction.
+export function deriveSessionKey(headers, body) {
   if (!headers) return null
   const auth = headers.authorization || headers['x-api-key'] || ''
   if (!auth) return null
-  return createHash('sha256').update(auth).digest('hex').slice(0, 16)
+  const seed = conversationSeed(body)
+  return createHash('sha256').update(`${auth} ${seed}`).digest('hex').slice(0, 16)
 }
 
 export function graphDeduplicateTargets(targets, bucket, { minBytes = MIN_BYTES } = {}) {

--- a/site/index.html
+++ b/site/index.html
@@ -470,8 +470,8 @@
      ============================================================ -->
 <section class="hero-section" id="hero">
     <div class="hero-inner">
-        <a href="#levels" class="release-chip" aria-label="What's new in v0.8.6">
-            <span class="release-chip__tag">v0.8.6</span>
+        <a href="#levels" class="release-chip" aria-label="What's new in v0.8.7">
+            <span class="release-chip__tag">v0.8.7</span>
             <span class="release-chip__text">zip-like 1–9 compression levels + Codex ChatGPT + Kimi CLI support</span>
             <span class="release-chip__arrow">&rarr;</span>
         </a>

--- a/test/br-cache.test.js
+++ b/test/br-cache.test.js
@@ -1,7 +1,7 @@
 import { describe, it, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { randomBytes } from 'node:crypto'
-import { mkdtempSync, rmSync, readdirSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync, readdirSync, writeFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { createBrCache } from '../lib/br-cache.js'
@@ -138,6 +138,26 @@ describe('br-cache — single payload larger than the whole budget', () => {
     // that get() can never resolve.
     assert.equal(put, null, 'put must not claim success for content it immediately evicts')
     assert.equal(cache.stats().entries, 0, 'no entry should remain on disk')
+  })
+})
+
+describe('br-cache — cached content is owner-only on disk', () => {
+  const parent = freshDir('perms')
+  after(() => rmSync(parent, { recursive: true, force: true }))
+
+  // Cached bodies are full tool_results (code, file contents, command output)
+  // and may contain secrets. They must not be readable by group/other.
+  it('creates cache files and dirs with no group/other access', { skip: process.platform === 'win32' }, () => {
+    const cacheDir = join(parent, 'br') // non-existent — br-cache must create it
+    const cache = createBrCache({ cacheDir, minSize: 10 })
+    const put = cache.put('sensitive cached tool_result body '.repeat(40))
+    assert.ok(put)
+    const shard = put.hash.slice(0, 2)
+    const filePath = join(cacheDir, shard, `${put.hash}.br`)
+
+    assert.equal(statSync(filePath).mode & 0o077, 0, 'cached file must not be group/other-readable')
+    assert.equal(statSync(join(cacheDir, shard)).mode & 0o077, 0, 'shard dir must not be group/other-accessible')
+    assert.equal(statSync(cacheDir).mode & 0o077, 0, 'cache dir must not be group/other-accessible')
   })
 })
 

--- a/test/docs.test.js
+++ b/test/docs.test.js
@@ -14,6 +14,21 @@ describe('docs and helper scripts', () => {
     assert.ok(!read('./../README.md').includes('OPENAI_BASE_URL='))
   })
 
+  it('suggests binding the llmlingua sidecar to localhost, not all interfaces', () => {
+    // The sidecar is a local-only helper (tamp's SSRF guard only connects to
+    // localhost). Suggesting --host 0.0.0.0 would expose it to the LAN.
+    const sources = ['./../index.js', './../README.md', './../bin/tamp.js']
+    for (const src of sources) {
+      const text = read(src)
+      if (text.includes('uvicorn')) {
+        assert.ok(
+          !text.includes('--host 0.0.0.0') && !text.includes("'0.0.0.0'"),
+          `${src} must not bind the sidecar to 0.0.0.0`
+        )
+      }
+    }
+  })
+
   it('keeps test-live.sh on current TAMP naming and repo-relative paths', () => {
     const script = read('./../test-live.sh')
     assert.ok(!script.includes('TOONA_'))

--- a/test/prune.test.js
+++ b/test/prune.test.js
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { compressText } from '../compress.js'
+
+// The prune stage (default-on at balanced/L5) strips npm lockfile noise. It
+// must only drop ACTUAL npm metadata — dropping a legitimately-named field
+// like { "integrity": "high" } in a non-npm tool_result would be silent data
+// loss, violating tamp's promise. `resolved` is already value-gated; this
+// extends the same discipline to `integrity` and `shasum`.
+const config = { minSize: 10, stages: ['prune'], llmLinguaUrl: null, log: false }
+
+function pruneOutput(obj) {
+  const r = compressText(JSON.stringify(obj, null, 2), config)
+  return r ? JSON.parse(r.text) : obj
+}
+
+describe('prune stage — only strips actual npm lockfile metadata', () => {
+  it('preserves non-npm fields named integrity/shasum (values are not hashes)', () => {
+    const out = pruneOutput({ integrity: 'high', shasum: 'verified', note: 'x'.repeat(120), id: 1 })
+    assert.equal(out.integrity, 'high', 'a non-hash integrity field must be preserved')
+    assert.equal(out.shasum, 'verified', 'a non-hash shasum field must be preserved')
+    assert.equal(out.id, 1)
+  })
+
+  it('still strips real npm SRI integrity and lockfile shasum hashes', () => {
+    const out = pruneOutput({
+      integrity: 'sha512-AbCdEf0123456789+/abcDEF==',
+      shasum: 'a'.repeat(40),
+      name: 'x'.repeat(120),
+    })
+    assert.equal(out.integrity, undefined, 'real SRI integrity hash should still be pruned')
+    assert.equal(out.shasum, undefined, 'real lockfile shasum should still be pruned')
+    assert.equal(out.name, 'x'.repeat(120))
+  })
+
+  it('strips npm-internal underscore keys and registry resolved URLs', () => {
+    const out = pruneOutput({
+      _id: 'pkg@1',
+      _from: 'pkg',
+      resolved: 'https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz',
+      keep: 'y'.repeat(120),
+    })
+    assert.equal(out._id, undefined)
+    assert.equal(out._from, undefined)
+    assert.equal(out.resolved, undefined)
+    assert.equal(out.keep, 'y'.repeat(120))
+  })
+
+  it('preserves a non-registry resolved URL (e.g. a git/file source)', () => {
+    const out = pruneOutput({ resolved: 'git+https://github.com/me/pkg.git', keep: 'z'.repeat(120) })
+    assert.equal(out.resolved, 'git+https://github.com/me/pkg.git', 'non-registry resolved must be preserved')
+  })
+})

--- a/test/rewriters-failure.test.js
+++ b/test/rewriters-failure.test.js
@@ -1,0 +1,184 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { rewriteCommandOutput, PRIORITY } from '../lib/rewriters/index.js'
+
+// Guardrail: a command-output rewriter may strip progress/spinner/banner noise,
+// but it must NEVER drop failure/error context. If a command FAILED, every
+// diagnostic line the agent needs (error codes, failed assertions, non-zero
+// exit summaries, HTTP errors, fatal:/ERROR: lines) must survive compression.
+// This locks in tamp's core promise for the lossy cmd-strip stage. Existing
+// fixtures cover only the success path; these cover the failure path.
+//
+// Each case: a realistic FAILED-command output that triggers the named
+// rewriter, plus the failure-signal substrings that must remain intact.
+const FAILURE_CASES = [
+  {
+    name: 'npm',
+    lines: [
+      'npm install leftpadx',
+      'npm error code E404',
+      'npm error 404 Not Found - GET https://registry.npmjs.org/leftpadx - Not found',
+      "npm error 404  'leftpadx@*' is not in this registry.",
+      'npm error A complete log of this run can be found in: /Users/x/.npm/_logs/2026.log',
+    ],
+    mustKeep: [
+      'npm error code E404',
+      'npm error 404 Not Found - GET https://registry.npmjs.org/leftpadx',
+      'npm error A complete log of this run can be found in:',
+    ],
+  },
+  {
+    name: 'pip',
+    lines: [
+      'Collecting frobnicate',
+      'ERROR: Could not find a version that satisfies the requirement frobnicate (from versions: none)',
+      'ERROR: No matching distribution found for frobnicate',
+    ],
+    mustKeep: [
+      'ERROR: Could not find a version that satisfies the requirement frobnicate',
+      'ERROR: No matching distribution found for frobnicate',
+    ],
+  },
+  {
+    name: 'cargo',
+    lines: [
+      '   Compiling myapp v0.1.0 (/work/myapp)',
+      'error[E0277]: the trait bound `String: Copy` is not satisfied',
+      ' --> src/main.rs:4:20',
+      'error: could not compile `myapp` (bin "myapp") due to 1 previous error',
+    ],
+    mustKeep: [
+      'error[E0277]: the trait bound `String: Copy` is not satisfied',
+      'error: could not compile `myapp` (bin "myapp") due to 1 previous error',
+    ],
+  },
+  {
+    name: 'docker',
+    lines: [
+      '#8 [builder 5/7] RUN npm ci',
+      '#8 DONE 4.2s',
+      '#9 [builder 6/7] RUN npm run build',
+      '#9 12.34 npm ERR! Build failed',
+      '#9 ERROR: process "/bin/sh -c npm run build" did not complete successfully: exit code: 1',
+      'ERROR: failed to solve: process "/bin/sh -c npm run build" did not complete successfully: exit code: 1',
+    ],
+    mustKeep: [
+      '#9 12.34 npm ERR! Build failed',
+      'ERROR: failed to solve: process "/bin/sh -c npm run build" did not complete successfully: exit code: 1',
+    ],
+  },
+  {
+    name: 'prisma',
+    lines: [
+      'Prisma schema loaded from prisma/schema.prisma',
+      'Datasource "db": PostgreSQL database "app" at "localhost:5432"',
+      "Error: P1001: Can't reach database server at `localhost:5432`",
+      'Please make sure your database server is running at `localhost:5432`.',
+    ],
+    mustKeep: [
+      "Error: P1001: Can't reach database server at `localhost:5432`",
+      'Please make sure your database server is running',
+    ],
+  },
+  {
+    name: 'terraform',
+    lines: [
+      'aws_instance.web: Refreshing state... [id=i-0abc123]',
+      'Terraform will perform the following actions',
+      'Plan: 0 to add, 0 to change, 0 to destroy.',
+      'Error: creating EC2 Instance: InvalidAMIID.NotFound: The image id does not exist',
+      '  status code: 400, request id: abcd-1234',
+    ],
+    mustKeep: [
+      'Plan: 0 to add, 0 to change, 0 to destroy.',
+      'Error: creating EC2 Instance: InvalidAMIID.NotFound',
+      'status code: 400',
+    ],
+  },
+  {
+    name: 'git',
+    lines: [
+      "Cloning into 'missing'...",
+      'remote: Counting objects: 100% (5/5), done.',
+      'remote: Repository not found.',
+      "fatal: repository 'https://github.com/x/missing.git/' not found",
+    ],
+    mustKeep: [
+      'remote: Repository not found.',
+      "fatal: repository 'https://github.com/x/missing.git/' not found",
+    ],
+  },
+  {
+    name: 'pytest',
+    lines: [
+      '=================== test session starts ===================',
+      'collected 1 item',
+      'tests/test_math.py F                                [100%]',
+      '    def test_add():',
+      '>       assert add(1, 2) == 4',
+      'E       assert 3 == 4',
+      'FAILED tests/test_math.py::test_add - assert 3 == 4',
+      '=== 1 failed in 0.12s ===',
+    ],
+    mustKeep: [
+      'FAILED tests/test_math.py::test_add - assert 3 == 4',
+      'E       assert 3 == 4',
+      '=== 1 failed in 0.12s ===',
+    ],
+  },
+  {
+    name: 'jest',
+    lines: [
+      'FAIL src/sum.test.js',
+      '  ✕ adds 1 + 2 (3 ms)',
+      '    expect(received).toBe(expected)',
+      '    Expected: 4',
+      '    Received: 3',
+      'Tests:       1 failed, 1 total',
+    ],
+    mustKeep: [
+      'FAIL src/sum.test.js',
+      'Expected: 4',
+      'Received: 3',
+      'Tests:       1 failed, 1 total',
+    ],
+  },
+  {
+    name: 'wget-curl',
+    lines: [
+      '  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current',
+      '                                 Dload  Upload   Total   Spent    Left  Speed',
+      '  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0',
+      'HTTP request sent, awaiting response... 404 Not Found',
+      'curl: (22) The requested URL returned error: 404',
+    ],
+    mustKeep: [
+      'curl: (22) The requested URL returned error: 404',
+      'HTTP request sent, awaiting response... 404 Not Found',
+    ],
+  },
+]
+
+describe('rewriters — failure context is never stripped', () => {
+  // Sanity: a case for every registered rewriter.
+  it('covers every rewriter in PRIORITY', () => {
+    assert.deepEqual(
+      [...PRIORITY].sort(),
+      FAILURE_CASES.map((c) => c.name).sort()
+    )
+  })
+
+  for (const { name, lines, mustKeep } of FAILURE_CASES) {
+    it(`${name}: preserves failure-signal lines`, () => {
+      const input = lines.join('\n')
+      const { text, rewriter } = rewriteCommandOutput(input)
+      assert.equal(rewriter, name, `failure output should route to the ${name} rewriter`)
+      for (const signal of mustKeep) {
+        assert.ok(
+          text.includes(signal),
+          `${name} rewriter dropped failure context: ${JSON.stringify(signal)}`
+        )
+      }
+    })
+  }
+})

--- a/test/session-graph.test.js
+++ b/test/session-graph.test.js
@@ -31,6 +31,41 @@ describe('deriveSessionKey', () => {
     assert.equal(deriveSessionKey({}), null)
     assert.equal(deriveSessionKey(null), null)
   })
+
+  describe('conversation scoping (prevents cross-conversation cache leakage)', () => {
+    const headers = { authorization: 'Bearer sk-SAME-TOKEN' }
+    const convA = { messages: [{ role: 'user', content: 'build a todo app' }] }
+    const convB = { messages: [{ role: 'user', content: 'debug my auth flow' }] }
+
+    it('same token but different conversation => different keys', () => {
+      assert.notEqual(deriveSessionKey(headers, convA), deriveSessionKey(headers, convB))
+    })
+
+    it('same conversation stays stable across turns (first turn is immutable)', () => {
+      const turn1 = { messages: [{ role: 'user', content: 'build a todo app' }] }
+      const turn3 = {
+        messages: [
+          { role: 'user', content: 'build a todo app' },
+          { role: 'assistant', content: 'ok' },
+          { role: 'user', content: 'now add tests' },
+        ],
+      }
+      assert.equal(deriveSessionKey(headers, turn1), deriveSessionKey(headers, turn3))
+    })
+
+    it('distinguishes conversations that differ only in system prompt', () => {
+      const a = { system: 'You are agent A', messages: [{ role: 'user', content: 'hi' }] }
+      const b = { system: 'You are agent B', messages: [{ role: 'user', content: 'hi' }] }
+      assert.notEqual(deriveSessionKey(headers, a), deriveSessionKey(headers, b))
+    })
+
+    it('no body => stable token-only key (backward compatible)', () => {
+      const k1 = deriveSessionKey(headers)
+      const k2 = deriveSessionKey(headers)
+      assert.equal(k1, k2)
+      assert.match(k1, /^[a-f0-9]{16}$/)
+    })
+  })
 })
 
 describe('createSessionStore', () => {

--- a/test/toon-fidelity.test.js
+++ b/test/toon-fidelity.test.js
@@ -1,0 +1,84 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { decode } from '@toon-format/toon'
+import { compressText } from '../compress.js'
+
+// Tamp's `toon` stage is marked LOSSLESS and runs by default (balanced preset).
+// The proxy emits TOON straight to the model without a round-trip check, so if
+// encode() ever mangled a value (delimiter collisions, type coercion of
+// numeric/boolean-looking strings, special keys, nesting), tamp would silently
+// corrupt tool-result content — a core-promise violation.
+//
+// This guardrail asserts that whatever compressText emits for JSON input is
+// FAITHFUL: a `toon` result must decode back to the original; a `minify`
+// result must JSON.parse back to the original. Adversarial shapes included.
+const config = { minSize: 10, stages: ['minify', 'toon'], llmLinguaUrl: null, log: false }
+
+const CASES = {
+  'comma in strings': [
+    { id: 1, note: 'hello, world', tag: 'a,b,c' },
+    { id: 2, note: 'plain', tag: 'x' },
+    { id: 3, note: 'one, two, three', tag: 'y,z' },
+  ],
+  'newline + quote in strings': [
+    { id: 1, s: 'line1\nline2', q: 'she said "hi"' },
+    { id: 2, s: 'single', q: 'none' },
+  ],
+  'numeric-looking strings stay strings': [
+    { id: 1, code: '007', zip: '01234' },
+    { id: 2, code: '42', zip: '99999' },
+  ],
+  'boolean-looking strings stay strings': [
+    { id: 1, flag: 'true', other: 'false' },
+    { id: 2, flag: 'maybe', other: 'no' },
+  ],
+  'null and boolean values': [
+    { id: 1, x: null, y: true },
+    { id: 2, x: 5, y: false },
+  ],
+  'nested objects': [
+    { id: 1, meta: { k: 'v', n: 3 } },
+    { id: 2, meta: { k: 'w', n: 4 } },
+  ],
+  'arrays of arrays': [
+    { id: 1, xs: [1, 2, 3] },
+    { id: 2, xs: [] },
+  ],
+  'unicode and emoji': [
+    { id: 1, s: 'héllo 🚀 日本語' },
+    { id: 2, s: 'café' },
+  ],
+  'string that looks like TOON syntax': [
+    { id: 1, s: 'a[2]{x,y}:' },
+    { id: 2, s: 'normal value' },
+  ],
+  'ragged keys across rows': [
+    { id: 1, a: 1 },
+    { id: 2, b: 2 },
+  ],
+}
+
+describe('toon stage — emitted output is always faithful to the original', () => {
+  for (const [name, value] of Object.entries(CASES)) {
+    it(`${name}: round-trips losslessly`, () => {
+      // Pretty-print so minify shrinks the body and the toon stage actually
+      // competes (compressText returns null for already-minified input).
+      const original = JSON.stringify(value, null, 2)
+      const result = compressText(original, config)
+      assert.ok(result, `compressText should compress pretty-printed JSON for "${name}"`)
+
+      let recovered
+      if (result.method === 'toon') {
+        recovered = decode(result.text)
+      } else {
+        // minify (or any JSON-preserving method) must parse back exactly
+        recovered = JSON.parse(result.text)
+      }
+      assert.deepStrictEqual(
+        recovered,
+        value,
+        `${result.method} output for "${name}" lost or altered data`
+      )
+    })
+  }
+})


### PR DESCRIPTION
## Fixes
- **fix(session-key)** — `read-diff`/`graph` caches were keyed on the API token alone, so conversations sharing a token shared one bucket. A new conversation could match a prior one's cached entry and have its tool_result replaced by a diff/marker against a base its model never saw — silent content loss on the **default** balanced path (read-diff is in L5). Now keys mix in a conversation-stable fingerprint (system + first turn); stable within a conversation, distinct across. Reproduced and fixed end-to-end.
- **fix(prune)** — value-gate `integrity`/`shasum` so a non-npm field like `{"integrity":"high"}` isn't dropped; real lockfile hashes still prune.
- **fix(br-cache)** — cached tool_result bodies written owner-only (`0600`/`0700`); they can contain secrets.
- **fix(sidecar)** — the "sidecar not running" hint now suggests `--host 127.0.0.1` (was `0.0.0.0`, LAN-exposed).

## Test guardrails (no behavior change)
- **test(rewriters)** — all 10 command rewriters proven to never strip failure/error context.
- **test(toon)** — emitted TOON always round-trips to the original (19 adversarial shapes verified).

## Context
- Full suite 596/596 (565 + 31 new tests).
- Each fix landed TDD (failing-first) across the improvement loop.
- Bumps 0.8.6 → 0.8.7 + landing chip. Merging triggers Cloudflare Pages; npm publish follows.
- No public API / env var / CLI changes.