### PR TITLE
docs(metadata): read-diff is default-on in balanced, not opt-in

### DIFF
--- a/metadata.js
+++ b/metadata.js
@@ -104,7 +104,7 @@ export const STAGE_DESCRIPTIONS = Object.freeze({
   'foundation-models': 'Apple Intelligence neural compression (macOS 15+, Apple Silicon, 100% local)',
   dedup: 'Deduplicate identical tool_results',
   diff: 'Replace similar re-reads with diffs',
-  'read-diff': 'Session-scoped unified diff for re-reads (lossless, opt-in)',
+  'read-diff': 'Session-scoped unified diff for re-reads (lossless, on by default in balanced+)',
   prune: 'Strip lockfile hashes & npm metadata',
   'strip-comments': 'Remove code comments (lossy)',
   textpress: 'LLM semantic compression (Ollama/OpenRouter)',


### PR DESCRIPTION
One-line fix: `STAGE_DESCRIPTIONS['read-diff']` said "(lossless, opt-in)" but read-diff ships in the default `balanced` preset (L5) and `STAGE_HINTS` already says "enabled by default." Corrects the mislabel shown in /caveman-help and banner output.

Docs-only string; no behavior change; full suite 600/600. No version bump — rides into the next functional release.