### PR TITLE
feat: redact secrets from outbound context (closes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ Supported on all providers: Anthropic, OpenAI Chat, OpenAI Responses (Codex), Ge
 | `TAMP_LOG` | `true` | Enable logging |
 | `TAMP_LOG_FILE` | *(none)* | Append logs to this file path, in addition to stderr |
 | `TAMP_CACHE_SAFE` | `true` | Compress newest only (prompt-cache safe) |
+| `TAMP_REDACT` | `true` | Mask secrets in tool output before anything leaves the machine |
+| `TAMP_REDACT_MODE` | `mask` | `mask` (replace with marker) or `remove` (delete value) |
 | `TAMP_LLMLINGUA_URL` | *(none)* | LLMLingua sidecar URL. Set to `http://localhost:8788` to skip the auto-probe (avoids startup race if sidecar is still loading the model) |
 
 **Recommended setups:**
@@ -363,7 +365,7 @@ The real win in v0.8 is **the level knob itself** — a zip-like 1–9 dial that
 
 Tamp runs on `localhost` and forwards to the upstream you configure. Most stages are local-only: `llmlingua` talks to a sidecar on `127.0.0.1`, `foundation-models` stays on-device. The one stage that sends content off-box is `textpress` (opt-in, level 7+), which posts to OpenRouter when `OPENROUTER_API_KEY` is set — leave it off if your tool output is sensitive.
 
-**Secret redaction** is on the roadmap ([#6](https://github.com/sliday/tamp/issues/6)): a `redact` stage that masks API keys, tokens, and `.env` values before anything leaves the machine, running ahead of every other stage. Until it lands, Tamp forwards file contents verbatim — treat your upstream's data policy as the boundary.
+**Secret redaction** is on by default ([#6](https://github.com/sliday/tamp/issues/6)). Before any stage runs — including ones that ship text off-box — Tamp masks high-confidence secrets in tool output: provider-shaped keys (AWS, GitHub, Anthropic/OpenAI, Google, Slack, Stripe), JWTs, PEM private-key blocks, and `UPPER_SNAKE` secret assignments from `.env`/shell (`API_TOKEN=…`, `DATABASE_PASSWORD=…`). Masking keeps structure (`API_TOKEN=‹redacted:secret›`) so the model still reasons about it. Set `TAMP_REDACT=false` to disable, or `TAMP_REDACT_MODE=remove` to delete rather than mask. Detection favors precision over recall: it won't catch every secret, so treat your upstream's data policy as the final boundary.
 
 This repo ships an agent harness (built with [harn.app](https://harn.app)): `AGENTS.md` plus PreToolUse / Stop hooks under `scripts/harness/` that block dangerous shell commands and gate completion on `npm test`. See `.claude/settings.json`.
 

--- a/compress.js
+++ b/compress.js
@@ -5,6 +5,7 @@ import { countTokens } from '@anthropic-ai/tokenizer'
 import { createPatch } from 'diff'
 import { tryParseJSON, classifyContent, stripLineNumbers, jsonHasUnsafeInteger } from './detect.js'
 import { rewriteCommandOutput } from './lib/rewriters/index.js'
+import { redactText } from './lib/redact.js'
 import { anthropic } from './providers.js'
 import { graphDeduplicateTargets } from './session-graph.js'
 import { detectTaskType, generateOutputRules, isDangerousTask } from './lib/rules-generator.js'
@@ -606,6 +607,20 @@ export async function compressRequest(body, config, provider) {
 
   const targets = provider.extract(body, { ...config, cacheSafe: config.cacheSafe !== false })
 
+  // Redaction runs FIRST (security, not compression): mask secrets in every
+  // target's text before any stage — dedup/diff/cache/llmlingua/textpress —
+  // sees it, so secrets never enter a disk cache or get shipped to a third
+  // party. We mutate target.text in place so the whole pipeline operates on
+  // the redacted body; the non-compressible case is closed in the loop below.
+  let redactedCount = 0
+  if (config.redact !== false) {
+    for (const target of targets) {
+      if (target.skip || typeof target.text !== 'string') continue
+      const r = redactText(target.text, config.redactMode)
+      if (r.count > 0) { target.text = r.text; target.redacted = true; redactedCount += r.count }
+    }
+  }
+
   // Read-diff: session-scoped unified diff for re-reads (lossless, opt-in)
   if (config.stages.includes('read-diff') && config.readCache && config.sessionKey && provider.name === 'anthropic') {
     readDiffTargets(targets, body, config.sessionKey, config.readCache)
@@ -670,12 +685,17 @@ export async function compressRequest(body, config, provider) {
     if (result) {
       target.compressed = result.text
       stats.push({ index: target.index, ...result })
+    } else if (target.redacted) {
+      // Not otherwise compressible, but it was redacted — apply() only writes
+      // back when .compressed is set, so push the redacted text through.
+      target.compressed = target.text
+      stats.push({ index: target.index, method: 'redact', originalLen: target.text.length, compressedLen: target.text.length, originalTokens: countTokens(target.text), compressedTokens: countTokens(target.text) })
     } else {
       stats.push({ index: target.index, skipped: 'not-compressible' })
     }
   }
   provider.apply(body, targets)
-  return { body, stats, targetCount: targets.length, outputHint, disclosure: disclosureStats }
+  return { body, stats, targetCount: targets.length, outputHint, disclosure: disclosureStats, redacted: redactedCount }
 }
 
 export async function compressMessages(body, config) {

--- a/config.js
+++ b/config.js
@@ -231,6 +231,11 @@ export function loadConfig(env = process.env, options = {}) {
     logFile: get('TAMP_LOG_FILE') || null,
     maxBody: parseInt(get('TAMP_MAX_BODY'), 10) || 10_485_760,
     cacheSafe: parseBoolean(get('TAMP_CACHE_SAFE'), true),
+    // Secret redaction is a security pass, not a compression stage: on by
+    // default at every level, masks secrets before any stage (incl. ones that
+    // ship text to third parties) sees the body. TAMP_REDACT=false disables it.
+    redact: parseBoolean(get('TAMP_REDACT'), true),
+    redactMode: get('TAMP_REDACT_MODE') === 'remove' ? 'remove' : 'mask',
     llmLinguaUrl: get('TAMP_LLMLINGUA_URL') || null,
     textpressOllamaUrl: get('TAMP_TEXTPRESS_OLLAMA_URL') || 'http://localhost:11434',
     textpressOllamaModel: get('TAMP_TEXTPRESS_OLLAMA_MODEL') || 'qwen3.5:0.8b',
@@ -286,6 +291,8 @@ export const CONFIG_TEMPLATE = `# Tamp configuration
 # TAMP_LOG_FILE=
 # TAMP_MAX_BODY=10485760
 # TAMP_CACHE_SAFE=true
+# TAMP_REDACT=true
+# TAMP_REDACT_MODE=mask
 # TAMP_TOKEN_COST=3
 # TAMP_FOUNDATION_MODELS_PATH=apfel
 # TAMP_FOUNDATION_MODELS_TIMEOUT=10000

--- a/lib/redact.js
+++ b/lib/redact.js
@@ -1,0 +1,73 @@
+// --- Secret redaction (security, not compression) ---
+//
+// Masks or removes high-confidence secrets in outbound tool_result bodies
+// before anything leaves the machine — and before any stage that ships text
+// to a third party (llmlingua sidecar, textpress/OpenRouter) ever sees it.
+//
+// Design bias: precision over recall. A false positive corrupts legitimate
+// content the model needs; a false negative leaks a secret. We only match
+// patterns with a recognizable shape (provider-prefixed keys, PEM blocks,
+// JWTs) plus assignment lines whose KEY name is unambiguously a secret. We do
+// NOT do entropy guessing — too noisy for code/log payloads.
+//
+// Why: https://github.com/sliday/tamp/issues/6
+
+// Each rule: a global regex and a short label used in the mask marker. Where a
+// rule needs to keep surrounding structure (assignments), it captures the
+// secret in group 1 and rebuilds the line via `replace`.
+const TOKEN_RULES = [
+  { label: 'aws-access-key', re: /\b(?:AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA)[0-9A-Z]{16}\b/g },
+  { label: 'github-token', re: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/g },
+  { label: 'github-pat', re: /\bgithub_pat_[A-Za-z0-9_]{60,}\b/g },
+  { label: 'anthropic-key', re: /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g },
+  { label: 'openai-key', re: /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/g },
+  { label: 'google-api-key', re: /\bAIza[0-9A-Za-z_-]{35}\b/g },
+  { label: 'slack-token', re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g },
+  { label: 'stripe-key', re: /\b[rs]k_live_[A-Za-z0-9]{20,}\b/g },
+  { label: 'google-oauth', re: /\bya29\.[A-Za-z0-9_-]{20,}\b/g },
+  { label: 'jwt', re: /\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g },
+  { label: 'private-key', re: /-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9 ]+ )?PRIVATE KEY-----/g },
+]
+
+// Assignment lines from .env / shell / config where the KEY name names a
+// secret. We mask only the VALUE, keeping the key so the model still sees the
+// variable exists.
+//
+// Precision rules learned the hard way:
+//   - Case-SENSITIVE uppercase keys only. Real secret env vars are UPPER_SNAKE
+//     (`API_KEY`, `AUTH_TOKEN`); camelCase like `apiKey = getKey()` is code,
+//     not a secret, and must not match.
+//   - The secret word is anchored to the END of the key (immediately before
+//     the `=`/`:`), so `AUTHOR=`, `COMPASS=`, `PASSWORD_HINT=` don't trip it.
+//   - Value must be 6+ non-space chars to skip empty/placeholder assignments.
+const SECRET_KEY = '[A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|CLIENT[_-]?SECRET|CREDENTIALS?|AUTH|PASSPHRASE|SESSION[_-]?KEY)'
+const ASSIGN_RE = new RegExp(
+  `((?:export\\s+)?${SECRET_KEY})(\\s*[:=]\\s*)(["']?)([^\\s"']{6,})(["']?)`,
+  'g'
+)
+
+function marker(label, mode) {
+  return mode === 'remove' ? '' : `‹redacted:${label}›`
+}
+
+// Returns { text, count }. `count` is the number of secrets masked/removed.
+// When count is 0 the returned text is referentially the input (no allocation
+// churn for the common no-secret case).
+export function redactText(text, mode = 'mask') {
+  if (typeof text !== 'string' || text.length === 0) return { text, count: 0 }
+
+  let count = 0
+  let out = text
+
+  for (const { label, re } of TOKEN_RULES) {
+    out = out.replace(re, () => { count++; return marker(label, mode) })
+  }
+
+  out = out.replace(ASSIGN_RE, (m, key, sep, q1, _val, q2) => {
+    count++
+    if (mode === 'remove') return `${key}${sep}`
+    return `${key}${sep}${q1}${marker('secret', mode)}${q2}`
+  })
+
+  return count > 0 ? { text: out, count } : { text, count: 0 }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sliday/tamp",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sliday/tamp",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sidecar/server.py",
     "sidecar/requirements.txt"
   ],
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Token compression proxy for coding agents. Works with Claude Code, Aider, Cursor, Cline, Windsurf. 60-70% combined input+output savings with Caveman-integrated presets and per-command rewriters.",
   "type": "module",
   "main": "index.js",

--- a/test/compress.test.js
+++ b/test/compress.test.js
@@ -164,6 +164,25 @@ describe('compressMessages', () => {
   })
 })
 
+describe('compressMessages — secret redaction', () => {
+  it('masks secrets in a tool_result even when the body is not compressible', async () => {
+    const secret = 'ghp_' + 'a'.repeat(36)
+    const body = { messages: [{ role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu_1', content: `API_TOKEN=${secret}` }] }] }
+    const { body: out, redacted } = await compressMessages(body, { ...cacheSafeConfig, redact: true })
+    const content = out.messages[0].content[0].content
+    assert.equal(content.includes(secret), false, 'secret must not reach the wire')
+    assert.equal(content.includes('‹redacted'), true)
+    assert.ok(redacted >= 1)
+  })
+
+  it('leaves content untouched when redaction is disabled', async () => {
+    const secret = 'ghp_' + 'b'.repeat(36)
+    const body = { messages: [{ role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu_1', content: `API_TOKEN=${secret}` }] }] }
+    const { body: out } = await compressMessages(body, { ...cacheSafeConfig, redact: false })
+    assert.equal(out.messages[0].content[0].content.includes(secret), true)
+  })
+})
+
 describe('compressMessages with llmlingua', () => {
   let mockServer
   let mockPort

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -19,6 +19,13 @@ describe('loadConfig', () => {
     assert.equal(cfg.cacheSafe, true)
     assert.equal(cfg.llmLinguaUrl, null)
     assert.equal(cfg.logFile, null)
+    assert.equal(cfg.redact, true)
+    assert.equal(cfg.redactMode, 'mask')
+  })
+
+  it('disables redaction with TAMP_REDACT=false and switches mode', () => {
+    assert.equal(loadConfig({ TAMP_REDACT: 'false' }).redact, false)
+    assert.equal(loadConfig({ TAMP_REDACT_MODE: 'remove' }).redactMode, 'remove')
   })
 
   it('overrides port from TAMP_PORT', () => {

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { redactText } from '../lib/redact.js'
+
+describe('redactText — provider-shaped tokens', () => {
+  it('masks AWS, GitHub, Anthropic, OpenAI, Google, Slack, Stripe keys', () => {
+    const cases = [
+      'AKIAIOSFODNN7EXAMPLE',
+      'ghp_' + 'a'.repeat(36),
+      'sk-ant-' + 'A'.repeat(40),
+      'sk-proj-' + 'B'.repeat(40),
+      'AIza' + 'C'.repeat(35),
+      'xoxb-' + '1'.repeat(20),
+      'sk_live_' + 'd'.repeat(24),
+    ]
+    for (const secret of cases) {
+      const { text, count } = redactText(`value=${secret} done`)
+      assert.equal(count >= 1, true, `should match ${secret}`)
+      assert.equal(text.includes(secret), false, `${secret} must not survive`)
+      assert.equal(text.includes('‹redacted:'), true)
+    }
+  })
+
+  it('masks a JWT and a PEM private key block', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiwidHlwIjoiSldUI.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N'
+    assert.equal(redactText(jwt).count, 1)
+    const pem = '-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA1\n-----END RSA PRIVATE KEY-----'
+    const out = redactText(pem)
+    assert.equal(out.count, 1)
+    assert.equal(out.text.includes('MIIEpAIBAAKCAQEA1'), false)
+  })
+})
+
+describe('redactText — assignment lines (.env / shell)', () => {
+  it('masks the value but keeps the key for secret-named vars', () => {
+    const env = 'API_KEY=abcd1234secret\nDATABASE_PASSWORD="hunter2hunter"\nexport AUTH_TOKEN=zzzzzzzz'
+    const { text, count } = redactText(env)
+    assert.equal(count, 3)
+    assert.equal(text.includes('abcd1234secret'), false)
+    assert.equal(text.includes('hunter2hunter'), false)
+    assert.equal(text.startsWith('API_KEY='), true)
+    assert.equal(text.includes('DATABASE_PASSWORD="‹redacted:secret›"'), true)
+  })
+
+  it('leaves non-secret assignments alone', () => {
+    const cfg = 'PORT=8080\nHOST=localhost\nDEBUG=true\nNAME=tamp'
+    assert.equal(redactText(cfg).count, 0)
+    assert.equal(redactText(cfg).text, cfg)
+  })
+})
+
+describe('redactText — precision (no false positives)', () => {
+  it('does not touch ordinary prose, code, or short values', () => {
+    const prose = 'The function returns a token count and the password field is empty.'
+    assert.equal(redactText(prose).count, 0)
+    const code = 'const apiKey = getKey()\nreturn sk_test_short'
+    assert.equal(redactText(code).count, 0)
+  })
+
+  it('returns the same reference when nothing matches', () => {
+    const s = 'nothing secret here'
+    assert.equal(redactText(s).text, s)
+  })
+})
+
+describe('redactText — remove mode', () => {
+  it('deletes the secret entirely', () => {
+    const { text, count } = redactText('token=ghp_' + 'a'.repeat(36), 'remove')
+    assert.equal(count, 1)
+    assert.equal(text.includes('‹redacted'), false)
+    assert.equal(/ghp_a+/.test(text), false)
+  })
+})


### PR DESCRIPTION
Closes #6 (@mrMemfis — "Remove confidential data from sending context").

## Problem
Tool output read from files (`.env`, configs, key dumps) flowed upstream verbatim — and to off-box stages (`textpress`/OpenRouter, the `llmlingua` sidecar) and disk caches. No way to strip or mask it. The only redaction that existed (`redactUrl` in `stats.js`) protects **logs**, not the request body.

## Solution
A security pass that masks high-confidence secrets in every `tool_result` body **before any stage sees it**.

- **`lib/redact.js`** — matches provider-shaped keys (AWS, GitHub, Anthropic/OpenAI, Google, Slack, Stripe), JWTs, PEM private-key blocks, and `UPPER_SNAKE` secret assignments from `.env`/shell. `mask` mode keeps structure (`API_TOKEN=‹redacted:secret›`) so the model still reasons; `remove` deletes the value.
- **Precision over recall** (false positives corrupt content the model needs): case-sensitive uppercase keys only, secret word anchored to the key suffix — so `apiKey = getKey()` (code), `AUTHOR=…`, `COMPASS=…` don't trip it. No entropy guessing.
- **Pipeline** — runs as the first pass in `compressRequest`, mutating `target.text` so dedup/diff/cache/llmlingua/textpress only ever see the redacted body. Non-compressible bodies (e.g. a small `.env` read) still reach the wire redacted via a fallback in the apply loop (`apply()` only writes `target.compressed`).
- **Config** — `TAMP_REDACT` (default **on**), `TAMP_REDACT_MODE` (`mask`|`remove`). Independent of the 1–9 compression ladder: security runs at every level, can't be dropped by picking level 1.

## Why a flag, not a stage
Secret handling is security, not compression. Keeping it off the level ladder means it's always-on, doesn't appear in savings stats, and survives `TAMP_STAGES=` overrides.

## Limitations
Detection favors precision: it won't catch every secret shape. README's Security section says so and keeps "treat your upstream's data policy as the final boundary."

## Tests
`lib/redact` unit suite + end-to-end redaction through `compressMessages` (including the non-compressible path) + config defaults. **620 pass / 0 fail**, smoke green. Bumps 0.8.8 → 0.8.9.