### PR TITLE
fix: kill quadratic ReDoS in secret redaction (v0.8.10)

### DIFF
--- a/lib/redact.js
+++ b/lib/redact.js
@@ -40,7 +40,12 @@ const TOKEN_RULES = [
 //   - The secret word is anchored to the END of the key (immediately before
 //     the `=`/`:`), so `AUTHOR=`, `COMPASS=`, `PASSWORD_HINT=` don't trip it.
 //   - Value must be 6+ non-space chars to skip empty/placeholder assignments.
-const SECRET_KEY = '[A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|CLIENT[_-]?SECRET|CREDENTIALS?|AUTH|PASSPHRASE|SESSION[_-]?KEY)'
+//   - The key prefix is BOUNDED (`{0,64}`) and word-boundary anchored. An
+//     unbounded `[A-Z0-9_]*` before the secret-word alternation is quadratic:
+//     on a long uppercase run with no match the engine retries every split
+//     point, so a big CONSTANT_CASE/hex tool_result would stall the proxy
+//     event loop for seconds. Real env-var names are well under 64 chars.
+const SECRET_KEY = '\\b[A-Z0-9_]{0,64}(?:SECRET|TOKEN|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|CLIENT[_-]?SECRET|CREDENTIALS?|AUTH|PASSPHRASE|SESSION[_-]?KEY)'
 const ASSIGN_RE = new RegExp(
   `((?:export\\s+)?${SECRET_KEY})(\\s*[:=]\\s*)(["']?)([^\\s"']{6,})(["']?)`,
   'g'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sliday/tamp",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sliday/tamp",
-      "version": "0.8.9",
+      "version": "0.8.10",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sidecar/server.py",
     "sidecar/requirements.txt"
   ],
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Token compression proxy for coding agents. Works with Claude Code, Aider, Cursor, Cline, Windsurf. 60-70% combined input+output savings with Caveman-integrated presets and per-command rewriters.",
   "type": "module",
   "main": "index.js",

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -63,6 +63,18 @@ describe('redactText — precision (no false positives)', () => {
   })
 })
 
+describe('redactText — ReDoS guard', () => {
+  it('stays linear on a large uppercase blob (no catastrophic backtracking)', () => {
+    // A 256KB CONSTANT_CASE run used to be O(n^2) via the unbounded key prefix
+    // and stalled the proxy event loop for seconds. Must complete near-instantly.
+    const blob = 'A'.repeat(256_000)
+    const start = process.hrtime.bigint()
+    redactText(blob)
+    const ms = Number(process.hrtime.bigint() - start) / 1e6
+    assert.ok(ms < 250, `redaction took ${ms.toFixed(0)}ms — expected < 250ms (ReDoS regression)`)
+  })
+})
+
 describe('redactText — remove mode', () => {
   it('deletes the secret entirely', () => {
     const { text, count } = redactText('token=ghp_' + 'a'.repeat(36), 'remove')


### PR DESCRIPTION
Follow-up to #19. `/review` caught a demonstrated DoS in the redact stage.

## Problem
`lib/redact.js` built the secret-assignment matcher with an unbounded `[A-Z0-9_]*` prefix — the same character class as the secret-word alternation that follows. On a long uppercase run with no match, the regex engine retries every split point: **O(n²)**.

Redaction runs on **every** tool_result, so a coding agent reading a file with a big `CONSTANT_CASE` block, uppercase hex table, or uppercase-base64 dump (well under the 10 MB `TAMP_MAX_BODY` cap) blocks the single Node event loop and stalls **all** in-flight requests through the proxy.

| input | before | after |
|---|---|---|
| 8 KB uppercase | 70 ms | 0.3 ms |
| 32 KB | 1.1 s | 0.1 ms |
| 64 KB | 4.4 s | 0.2 ms |
| 256 KB | ~70 s | 0.8 ms |

## Fix
Bound the key prefix to `{0,64}` and word-boundary anchor it:
```js
const SECRET_KEY = '\\b[A-Z0-9_]{0,64}(?:SECRET|TOKEN|...)'
```
Real env-var names are far under 64 chars, so recall is unchanged; matching is now linear. Adds a 256 KB regression test asserting < 250 ms.

## Tests
**621 pass / 0 fail**. Masking correctness preserved (env vars masked, `apiKey = getKey()` still not a false positive). Bumps 0.8.9 → 0.8.10.