### PR TITLE
fix: kill 3 quadratic ReDoS regexes on the compression hot path (v0.8.11)

### DIFF
--- a/compress.js
+++ b/compress.js
@@ -24,9 +24,17 @@ function cacheKey(text) {
 export function clearCache() { cache.clear() }
 
 function normalizeWhitespace(text) {
-  return text
-    .replace(/[ \t]+$/gm, '')
-    .replace(/\n{3,}/g, '\n\n')
+  // Right-trim each line by hand. The former `/[ \t]+$/gm` is quadratic: a long
+  // run of spaces/tabs NOT at line end makes the greedy match restart at every
+  // offset, so a padded/aligned tool_result (tables, ASCII art) stalled the
+  // proxy event loop for seconds. This scan touches each char once.
+  let out = ''
+  for (let line of text.split('\n')) {
+    let e = line.length
+    while (e > 0 && (line[e - 1] === ' ' || line[e - 1] === '\t')) e--
+    out += (e === line.length ? line : line.slice(0, e)) + '\n'
+  }
+  return out.slice(0, -1).replace(/\n{3,}/g, '\n\n')
 }
 
 // --- Stage: dedup ---
@@ -238,12 +246,46 @@ function stripLineComments(line) {
   return line
 }
 
+// Remove line-level `/* ... */` block comments (opener at start of line after
+// optional spaces/tabs) and `<!-- ... -->` HTML comments, in ONE linear pass.
+// A regex can't do this without O(n^2): `/^[ \t]*\/\*[\s\S]*?\*\//gm` rescans to
+// EOF at every unclosed opener, so a file full of `/*` line-starts stalled the
+// event loop (256 KB took ~40s). An unterminated comment is left unchanged, to
+// match the old lazy regex (which required a closing delimiter to match).
+function stripBlockAndHtmlComments(text) {
+  let out = ''
+  let i = 0
+  const n = text.length
+  let lineStart = true
+  while (i < n) {
+    if (lineStart) {
+      let j = i
+      while (j < n && (text[j] === ' ' || text[j] === '\t')) j++
+      if (text[j] === '/' && text[j + 1] === '*') {
+        const close = text.indexOf('*/', j + 2)
+        if (close === -1) { out += text.slice(i); break }
+        i = close + 2
+        lineStart = false
+        continue
+      }
+    }
+    if (text[i] === '<' && text.startsWith('<!--', i)) {
+      const close = text.indexOf('-->', i + 4)
+      if (close === -1) { out += text.slice(i); break }
+      i = close + 3
+      lineStart = false
+      continue
+    }
+    const c = text[i]
+    out += c
+    lineStart = c === '\n'
+    i++
+  }
+  return out
+}
+
 function stripComments(text) {
-  // Block comments: only strip if they start at line-level (not inside strings)
-  let result = text
-    .replace(/^[ \t]*\/\*\*[\s\S]*?\*\//gm, '')
-    .replace(/^[ \t]*\/\*[\s\S]*?\*\//gm, '')
-    .replace(/<!--[\s\S]*?-->/g, '')
+  let result = stripBlockAndHtmlComments(text)
   result = result.split('\n').map(stripLineComments).join('\n')
   return result.replace(/\n\s*\n\s*\n/g, '\n\n')
 }

--- a/detect.js
+++ b/detect.js
@@ -82,7 +82,12 @@ export function tryParseJSON(str) {
 export function isTOON(str) {
   if (typeof str !== 'string') return false
   const firstLine = str.trimStart().split('\n')[0]
-  return /^\[TOON\]/.test(firstLine) || /\w+\[\d+\]\{/.test(firstLine) || /\w+\[\d+\]:/.test(firstLine)
+  // Anchored + bounded. The former unanchored `\w+\[\d+\]\{` was quadratic: on a
+  // long word-char run with no bracket the greedy `\w+` backtracks and, being
+  // unanchored, retries at every offset — a single-line blob (minified JSON, a
+  // long token) stalled the event loop. TOON headers begin the line, so `^`
+  // alone kills it; the {1,64}/{1,15} bounds are belt-and-suspenders.
+  return /^\[TOON\]/.test(firstLine) || /^\s*\w{1,64}\[\d{1,15}\]\{/.test(firstLine) || /^\s*\w{1,64}\[\d{1,15}\]:/.test(firstLine)
 }
 
 export function classifyContent(str) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sliday/tamp",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sliday/tamp",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sidecar/server.py",
     "sidecar/requirements.txt"
   ],
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Token compression proxy for coding agents. Works with Claude Code, Aider, Cursor, Cline, Windsurf. 60-70% combined input+output savings with Caveman-integrated presets and per-command rewriters.",
   "type": "module",
   "main": "index.js",

--- a/test/compress.test.js
+++ b/test/compress.test.js
@@ -9,6 +9,30 @@ import { createSessionStore } from '../session-graph.js'
 const fixtures = JSON.parse(readFileSync(new URL('./fixtures/sample-messages.json', import.meta.url), 'utf-8'))
 
 const defaultConfig = { minSize: 50, stages: ['minify'], llmLinguaUrl: null }
+
+describe('compressText — ReDoS guards', () => {
+  const timed = (fn) => { const s = process.hrtime.bigint(); fn(); return Number(process.hrtime.bigint() - s) / 1e6 }
+
+  it('normalizeWhitespace stays linear on a long space run (whitespace stage)', () => {
+    const cfg = { minSize: 50, stages: ['whitespace'], llmLinguaUrl: null, log: false }
+    const ms = timed(() => compressText(' '.repeat(256_000) + 'x', cfg))
+    assert.ok(ms < 300, `took ${ms.toFixed(0)}ms — expected < 300ms (ReDoS regression)`)
+  })
+
+  it('stripComments stays linear on many unclosed block openers', () => {
+    const cfg = { minSize: 50, stages: ['strip-comments'], llmLinguaUrl: null, log: false }
+    const ms = timed(() => compressText('/**\n'.repeat(64_000), cfg))
+    assert.ok(ms < 400, `took ${ms.toFixed(0)}ms — expected < 400ms (ReDoS regression)`)
+  })
+
+  it('stripComments still removes line-level block and HTML comments', () => {
+    const cfg = { minSize: 5, stages: ['strip-comments'], llmLinguaUrl: null, log: false }
+    const a = compressText('/* c */\nkeep this content line long enough to pass minSize', cfg)
+    assert.ok(a && !a.text.includes('/* c */'))
+    const b = compressText('<!-- x -->keep this content line long enough to pass minSize', cfg)
+    assert.ok(b && !b.text.includes('<!--'))
+  })
+})
 const toonConfig = { minSize: 50, stages: ['minify', 'toon'], llmLinguaUrl: null }
 const cacheSafeConfig = { minSize: 50, stages: ['minify'], llmLinguaUrl: null, cacheSafe: true }
 const allHistoryConfig = { minSize: 50, stages: ['minify'], llmLinguaUrl: null, cacheSafe: false }

--- a/test/detect.test.js
+++ b/test/detect.test.js
@@ -88,6 +88,15 @@ describe('isTOON', () => {
   it('rejects non-string', () => {
     assert.equal(isTOON(123), false)
   })
+
+  it('stays linear on a large single-line blob (ReDoS guard)', () => {
+    // Unanchored `\w+\[\d+\]\{` was O(n^2): a long word-char run with no bracket
+    // backtracked at every offset and stalled the proxy. Must be near-instant.
+    const start = process.hrtime.bigint()
+    isTOON('a'.repeat(256_000))
+    const ms = Number(process.hrtime.bigint() - start) / 1e6
+    assert.ok(ms < 250, `isTOON took ${ms.toFixed(0)}ms — expected < 250ms (ReDoS regression)`)
+  })
 })
 
 describe('classifyContent', () => {


### PR DESCRIPTION
Security sweep (via `/loop`) of existing tamp stages. Found three O(n²) regexes that run on untrusted tool output on the single event loop — a slow match stalls **every** in-flight request through the proxy, not just the offender. All confirmed with timing, all fixed and regression-guarded.

| location | trigger | scope | 64 KB before → after |
|---|---|---|---|
| `normalizeWhitespace` compress.js | long space/tab run not at line end | **every preset (default)** | 5.9 s → 6 ms |
| `isTOON` detect.js | long single-line blob (minified JSON, token) | **every input** (classifyContent) | 5.1 s → 0.2 ms |
| `stripComments` compress.js | many unclosed `/*` line-starts | aggressive preset | 41 s @256KB → 21 ms |

## Root cause + fix
- **whitespace**: `/[ \t]+$/gm` — greedy run restarts at every offset when it's not at line end. → per-line manual right-trim (each char touched once).
- **isTOON**: unanchored `\w+\[\d+\]\{` — `\w+` backtracks at every start offset. → anchored `^` + bounded `{1,64}`/`{1,15}` (TOON headers begin the line, so recall unchanged).
- **stripComments**: `/^[ \t]*\/\*[\s\S]*?\*\//gm` — rescans to EOF at every unclosed opener; a regex can't avoid this. → single linear pass scanning line-level `/* */` and `<!-- -->`, leaving unterminated comments unchanged (matches old semantics).

## Tests
4 new ReDoS guards (256 KB asserts < 250-400 ms) + block/HTML strip correctness. **625 pass / 0 fail**, smoke green. Bumps 0.8.10 → 0.8.11. Companion to #20 (redact ReDoS).