### PR TITLE
fix: stop leaking secret query params to logs + harden piped abort (v0.8.13)

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,6 +175,13 @@ function pipeRequest(req, res, upstreamUrl, prefixChunks) {
   const headers = { ...req.headers }
   delete headers.host
   const upstream = openUpstream(req.method, upstreamUrl, headers, res)
+  // Guard the inbound stream: a client RST mid-upload emits 'error' on `req`,
+  // and with no listener Node rethrows it and crashes the whole proxy. The
+  // buffered path already guards this; the piped passthrough must too.
+  req.on('error', (err) => {
+    log(`[tamp] client upload error: ${err.code || ''} ${err.message}`)
+    upstream.destroy()
+  })
   if (prefixChunks) {
     for (const chunk of prefixChunks) upstream.write(chunk)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sliday/tamp",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sliday/tamp",
-      "version": "0.8.12",
+      "version": "0.8.13",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sidecar/server.py",
     "sidecar/requirements.txt"
   ],
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "Token compression proxy for coding agents. Works with Claude Code, Aider, Cursor, Cline, Windsurf. 60-70% combined input+output savings with Caveman-integrated presets and per-command rewriters.",
   "type": "module",
   "main": "index.js",

--- a/stats.js
+++ b/stats.js
@@ -13,7 +13,12 @@ const c = {
 // (Gemini and OpenAI-compatible gateways) carry the API key in the query
 // string (?key=, ?api_key=), which would otherwise land in stdout, log
 // files, and the systemd journal. Path-relative URLs only — no base needed.
-const SECRET_QUERY_PARAM = /^(key|api_key|apikey|access_token|token)$/i
+// Keyword (substring) match on the param NAME, not an exact list. The old
+// anchored `^(key|api_key|apikey|access_token|token)$` leaked `refresh_token`,
+// `id_token`, `client_secret`, `password`, `session`, `sig`/`signature`, `auth`
+// to stdout / TAMP_LOG_FILE / the systemd journal. Over-redacting a benign
+// param name in a log is harmless; leaking a credential is not.
+const SECRET_QUERY_PARAM = /key|token|secret|password|passwd|sig|auth|session|credential/i
 export function redactUrl(url) {
   if (typeof url !== 'string') return url
   const q = url.indexOf('?')
@@ -51,7 +56,7 @@ export function formatRequestLog(stats, session, providerName, url, bodySize, to
   const totalComp = compressed.reduce((a, s) => a + s.compressedLen, 0)
   const totalOrigTok = compressed.reduce((a, s) => a + (s.originalTokens || 0), 0)
   const totalCompTok = compressed.reduce((a, s) => a + (s.compressedTokens || 0), 0)
-  const pct = (((totalOrig - totalComp) / totalOrig) * 100).toFixed(1)
+  const pct = (totalOrig > 0 ? ((totalOrig - totalComp) / totalOrig) * 100 : 0).toFixed(1)
   const saved = totalOrig - totalComp
   const tokSaved = totalOrigTok - totalCompTok
 
@@ -60,7 +65,7 @@ export function formatRequestLog(stats, session, providerName, url, bodySize, to
   lines.push(`[tamp] ${c.cyan}${label}${c.reset} ${path}${sizeInfo} ${c.green}— ${n} block${n !== 1 ? 's' : ''} compressed, -${pct}%${c.reset}`)
 
   for (const s of compressed) {
-    const sPct = (((s.originalLen - s.compressedLen) / s.originalLen) * 100).toFixed(1)
+    const sPct = (s.originalLen > 0 ? ((s.originalLen - s.compressedLen) / s.originalLen) * 100 : 0).toFixed(1)
     const tokInfo = s.originalTokens ? ` ${c.dim}${s.originalTokens}→${s.compressedTokens} tok${c.reset}` : ''
     lines.push(`[tamp]   ${c.dim}block[${s.index}]${c.reset} ${fmtSize(s.originalLen)}→${fmtSize(s.compressedLen)} ${c.green}-${sPct}%${c.reset}${tokInfo} ${c.dim}[${s.method}]${c.reset}`)
   }

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -19,6 +19,15 @@ describe('redactUrl', () => {
     assert.ok(out.includes('access_token=REDACTED'))
   })
 
+  it('masks secret params the old exact-match list leaked', () => {
+    const out = redactUrl('/v1/x?refresh_token=RT&client_secret=CS&id_token=ID&password=P&signature=SG')
+    for (const secret of ['RT', 'CS', 'ID', 'P', 'SG']) {
+      assert.ok(!out.includes(`=${secret}`), `${secret} must be redacted`)
+    }
+    assert.ok(out.includes('refresh_token=REDACTED'))
+    assert.ok(out.includes('client_secret=REDACTED'))
+  })
+
   it('returns urls without a query string unchanged', () => {
     assert.equal(redactUrl('/v1/messages'), '/v1/messages')
   })


### PR DESCRIPTION
Third `/loop` security sweep — audited index.js decompression/streaming and the CLI (bin/tamp.js) + stats.js. Decompression/response paths came back **clean** (every decode path size-capped incl. the hand-rolled zstd; SSE streaming preserved). Fixes below; two lower-severity items flagged for your call.

## [P2 security] Secret query params leaked to logs
`stats.js` `redactUrl` used an anchored exact-match list:
```js
const SECRET_QUERY_PARAM = /^(key|api_key|apikey|access_token|token)$/i
```
So `refresh_token`, `id_token`, `client_secret`, `password`, `session`, `sig`/`signature`, `auth` all wrote **verbatim** to stdout, `TAMP_LOG_FILE`, and the systemd journal (verified: `?client_secret=CS&refresh_token=RT` passed through unredacted). Switched to a keyword substring match on the param name. Over-redacting a benign name in a log is harmless; leaking a credential is not. Stays linear (800 K query string = 16 ms). Regression test added.

## [P2 hardening] Piped passthrough could crash on client abort
`index.js` `pipeRequest` did `req.pipe(upstream)` with no `req.on('error')`. The buffered read path already guards a client RST mid-upload (explicit try/catch); the piped passthrough lacked the symmetric guard, so a stream `'error'` there had no listener → Node rethrows → process exit, killing every in-flight request. Added the mirror handler that destroys upstream. (The existing passthrough-abort integration test already passes; this closes the asymmetry the buffered path's comment warns about.)

## [P3 cosmetic] -NaN% in logs
Divide-by-zero when a compressed block had `originalLen 0`. Guarded the total and per-block percentages.

## Flagged, NOT changed (your call)
- **`tamp stop` PID reuse** (bin/tamp.js ~350): SIGTERMs the pid-file PID without confirming it's still Tamp; if the OS recycled the PID, `stop` could kill an unrelated process. There's already a `docs/notes-stop-pid-reuse.md`, so it looks tracked. Fix: verify via `/health` version or `startedAt` before killing.
- **Config file perms**: `~/.config/tamp/config` (documented home for `OPENROUTER_API_KEY`) is written with default umask (world-readable 0644). Consider `mode: 0o600`.

## Tests
626 pass / 0 fail, smoke green. Bumps 0.8.11 → 0.8.13 (0.8.12 is claimed by open #22).