### PR TITLE
fix: prototype-key config crashes + bm25 last-line anchor (v0.8.14)

### DIFF
--- a/config.js
+++ b/config.js
@@ -37,14 +37,17 @@ function coerceLevelInput(raw) {
     const v = resolveLevel(n) ? n : null
     return { value: v, valid: v !== null }
   }
-  if (s in LEVEL_ALIASES) return { value: s, valid: true }
+  // Object.hasOwn, NOT `in`: `in` walks the prototype chain, so
+  // TAMP_LEVEL=constructor / toString / valueOf pass as valid and later crash
+  // stagesForLevel with an inherited function instead of falling back cleanly.
+  if (Object.hasOwn(LEVEL_ALIASES, s)) return { value: s, valid: true }
   return { value: null, valid: false }
 }
 
 // Convert a level input (number or alias) to its canonical integer.
 function levelInputToInt(input) {
   if (typeof input === 'number') return input
-  if (typeof input === 'string' && input in LEVEL_ALIASES) return LEVEL_ALIASES[input]
+  if (typeof input === 'string' && Object.hasOwn(LEVEL_ALIASES, input)) return LEVEL_ALIASES[input]
   return null
 }
 
@@ -152,7 +155,10 @@ export function loadConfig(env = process.env, options = {}) {
       stages = stagesForLevel(level)
       levelSource = chosen.source
     } else if (presetExplicit) {
-      const preset = COMPRESSION_PRESETS[presetNameRaw]
+      // Object.hasOwn guard: a bare `COMPRESSION_PRESETS[presetNameRaw]` lets
+      // __proto__/constructor/toString return truthy prototype objects that
+      // pass the `if (preset)` check and then crash on `...preset.stages`.
+      const preset = Object.hasOwn(COMPRESSION_PRESETS, presetNameRaw) ? COMPRESSION_PRESETS[presetNameRaw] : null
       if (preset) {
         stages = [...preset.stages]
         level = typeof preset.level === 'number' ? preset.level : null
@@ -225,7 +231,7 @@ export function loadConfig(env = process.env, options = {}) {
     levelSource,
     outputMode,
     outputModeDefault: defaultOutputMode && VALID_OUTPUT_MODES.has(defaultOutputMode) ? defaultOutputMode : null,
-    agent: get('TAMP_AGENT') || null,
+    agent: get('TAMP_AGENT')?.toLowerCase() || null,
     autoDetectTaskType: parseBoolean(get('TAMP_AUTO_DETECT_TASK_TYPE'), true),
     log: get('TAMP_LOG') !== 'false',
     logFile: get('TAMP_LOG_FILE') || null,

--- a/lib/bm25.js
+++ b/lib/bm25.js
@@ -133,7 +133,15 @@ export function trimLinesByRelevance(text, query, { targetTokens = 4096, minLine
   const keep = new Uint8Array(N)
   keep[0] = 1
   keep[N - 1] = 1
-  let budgetUsed = lineTokens[0] + (N > 1 ? lineTokens[N - 1] : 0)
+  // Anchor the last NON-EMPTY line too. Tool output almost always ends with
+  // '\n', so lines[N-1] is '' — pinning only that empty terminator would let
+  // the real final line (often a trailing error or stack trace, exactly the
+  // "context anchor" this claims to preserve) be dropped as a candidate.
+  let lastReal = N - 1
+  while (lastReal > 0 && lines[lastReal] === '') lastReal--
+  keep[lastReal] = 1
+  let budgetUsed = 0
+  for (const idx of new Set([0, N - 1, lastReal])) budgetUsed += lineTokens[idx]
   // Rough marker cost reserved per collapsed gap; we'll reconcile below.
   const MARKER_RESERVE = 16
 
@@ -141,6 +149,7 @@ export function trimLinesByRelevance(text, query, { targetTokens = 4096, minLine
   // context preferred on ties). We pick greedily until budget is hit.
   const candidates = []
   for (let i = 1; i < N - 1; i++) {
+    if (keep[i]) continue // skip already-anchored lines (e.g. lastReal)
     candidates.push({ i, score: scores[i], len: lineTokens[i] })
   }
   candidates.sort((a, b) => (b.score - a.score) || (a.i - b.i))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sliday/tamp",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sliday/tamp",
-      "version": "0.8.13",
+      "version": "0.8.14",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sidecar/server.py",
     "sidecar/requirements.txt"
   ],
-  "version": "0.8.13",
+  "version": "0.8.14",
   "description": "Token compression proxy for coding agents. Works with Claude Code, Aider, Cursor, Cline, Windsurf. 60-70% combined input+output savings with Caveman-integrated presets and per-command rewriters.",
   "type": "module",
   "main": "index.js",

--- a/test/bm25-trim.test.js
+++ b/test/bm25-trim.test.js
@@ -225,3 +225,13 @@ describe('bm25-trim — stage disabled', () => {
     assert.equal(after.length, body.length, 'body must pass through untouched')
   })
 })
+
+describe('trimLinesByRelevance - last-line anchor with trailing newline', () => {
+  it('preserves the real final line (trailing error) when the body ends in a newline', () => {
+    const noise = Array.from({ length: 2000 }, (_, i) => `processing item ${i} widget gadget`).join('\n')
+    const text = noise + '\nERROR_AT_END: unhandled exception in widget parser\n'
+    const r = trimLinesByRelevance(text, 'widget', { targetTokens: 300 })
+    assert.ok(r, 'should produce a trim')
+    assert.ok(r.text.includes('ERROR_AT_END'), 'trailing error line must survive the trim')
+  })
+})

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -347,4 +347,17 @@ describe('loadConfig — level precedence matrix (Phase C)', () => {
       }
     }
   })
+
+  it('does not crash on prototype-chain keys in TAMP_LEVEL / TAMP_COMPRESSION_PRESET', () => {
+    for (const bad of ['constructor', 'toString', 'valueOf', 'hasOwnProperty', '__proto__']) {
+      const a = loadConfig({ TAMP_LEVEL: bad })
+      assert.ok(Array.isArray(a.stages) && a.stages.length > 0, `TAMP_LEVEL=${bad} must fall back cleanly`)
+      const b = loadConfig({ TAMP_COMPRESSION_PRESET: bad })
+      assert.ok(Array.isArray(b.stages) && b.stages.length > 0, `TAMP_COMPRESSION_PRESET=${bad} must fall back cleanly`)
+    }
+  })
+
+  it('lowercases TAMP_AGENT so per-agent overrides resolve', () => {
+    assert.equal(loadConfig({ TAMP_AGENT: 'Codex' }).agent, 'codex')
+  })
 })


### PR DESCRIPTION
Fourth `/loop` security sweep — audited config parsing, bm25, path-extract, and the output-rule injection path.

## [P2 security] Env-triggered startup crash via prototype-chain keys
`config.js` validated `TAMP_LEVEL` with the `in` operator and indexed `COMPRESSION_PRESETS` directly for `TAMP_COMPRESSION_PRESET`. Both walk the prototype chain, so these pass validation then crash `loadConfig`:
```
TAMP_LEVEL=constructor       -> Cannot read properties of undefined (reading 'stages')
TAMP_LEVEL=toString/valueOf  -> same
TAMP_COMPRESSION_PRESET=__proto__ / constructor -> preset.stages is not iterable
```
(Reproduced on `main`.) A hostile or fat-fingered env var takes the proxy down at startup instead of warning + falling back to defaults. Fixed by switching both lookups to `Object.hasOwn`.

## [P2 correctness] bm25-trim drops the real final line
The stage documents 'First and last lines are always preserved as context anchors', but it anchored `keep[N-1]`. Tool output almost always ends with `\n`, so `lines[N-1]` is `''` — the empty terminator gets pinned while the actual last content line (often a trailing error / stack trace) is dropped as an ordinary candidate. Verified: a body ending `...ERROR_AT_END...\n` lost the error. Now anchors the last **non-empty** line and skips already-anchored lines when building candidates (no budget double-count).

## [P3] TAMP_AGENT case
Not lowercased, so `TAMP_AGENT=Codex` silently missed the lowercase-keyed per-agent overrides. Normalized.

## Flagged, NOT changed
`rules-generator.js` `injectOutputRules` truncates a CLAUDE.md (drops everything after an existing rules section) — but it's **dead code** (exported, zero callers), so not on any live path. Worth deleting or fixing if you plan to use it.

## Also audited, clean
Output-rule injection is fully static (no untrusted/tool content flows into injected text; targets only user messages; prompt-cache prefix preserved). bm25 tokenize + path-extract: no ReDoS (<1.1ms @64KB). Numeric env parsing: `TAMP_MAX_BODY=0` falls back to 10MB (cap not disabled). `TAMP_STAGES` filtered against `ALL_STAGES` (unknown/proto keys dropped).

## Tests
3 regression tests. **628 pass / 0 fail**, smoke green. Bumps 0.8.11 → 0.8.14.