### PR TITLE
fix: bind proxy to loopback by default, not all interfaces (v0.8.15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Supported on all providers: Anthropic, OpenAI Chat, OpenAI Responses (Codex), Ge
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TAMP_PORT` | `7778` | Listen port |
+| `TAMP_HOST` | `127.0.0.1` | Bind address. Loopback by default; set `0.0.0.0` to expose beyond the local machine (e.g. in a container) |
 | `TAMP_UPSTREAM` | `https://api.anthropic.com` | Anthropic (default) upstream |
 | `TAMP_UPSTREAM_OPENAI` | `https://api.openai.com` | Upstream for OpenAI-compatible routes (`/v1/chat/completions`, `/v1/responses`) |
 | `TAMP_UPSTREAM_GEMINI` | `https://generativelanguage.googleapis.com` | Upstream for Gemini (`generateContent`) routes |

--- a/bin/tamp.js
+++ b/bin/tamp.js
@@ -529,7 +529,7 @@ if (skipPrompt) {
     process.exit(1)
   })
 
-  server.listen(config.port, () => {
+  server.listen(config.port, config.host, () => {
     try { writePidFile(config.port) } catch (err) {
       console.error(`[tamp] Warning: could not write PID file: ${err.message}`)
     }

--- a/config.js
+++ b/config.js
@@ -206,6 +206,11 @@ export function loadConfig(env = process.env, options = {}) {
   return Object.freeze({
     version: VERSION,
     port: parseInt(get('TAMP_PORT'), 10) || 7778,
+    // Bind loopback by default. The proxy forwards the caller's API key to the
+    // upstream, so binding all interfaces (the old no-host default) turned any
+    // LAN peer into an authenticated relay. Set TAMP_HOST=0.0.0.0 to opt into
+    // broader binding (e.g. inside a container).
+    host: get('TAMP_HOST') || '127.0.0.1',
     upstream: get('TAMP_UPSTREAM') || 'https://api.anthropic.com',
     upstreams: Object.freeze({
       anthropic: get('TAMP_UPSTREAM') || 'https://api.anthropic.com',
@@ -259,6 +264,7 @@ export const CONFIG_TEMPLATE = `# Tamp configuration
 # https://github.com/sliday/tamp
 
 # TAMP_PORT=7778
+# TAMP_HOST=127.0.0.1   # bind address; set 0.0.0.0 to expose beyond loopback
 # TAMP_UPSTREAM=https://api.anthropic.com
 # TAMP_UPSTREAM_OPENAI=https://api.openai.com
 # TAMP_UPSTREAM_GEMINI=https://generativelanguage.googleapis.com

--- a/index.js
+++ b/index.js
@@ -422,8 +422,8 @@ const isMain = !process.argv[1]?.includes('node_modules') && process.argv[1] ===
 
 if (isMain) {
   const { config, server } = createProxy()
-  server.listen(config.port, () => {
-    console.error(`[tamp] proxy listening on http://localhost:${config.port}`)
+  server.listen(config.port, config.host, () => {
+    console.error(`[tamp] proxy listening on http://${config.host}:${config.port}`)
     console.error(`[tamp] upstream: ${config.upstream}`)
     console.error(`[tamp] stages: ${config.stages.join(', ')}`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sliday/tamp",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sliday/tamp",
-      "version": "0.8.14",
+      "version": "0.8.15",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/tokenizer": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "sidecar/server.py",
     "sidecar/requirements.txt"
   ],
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "Token compression proxy for coding agents. Works with Claude Code, Aider, Cursor, Cline, Windsurf. 60-70% combined input+output savings with Caveman-integrated presets and per-command rewriters.",
   "type": "module",
   "main": "index.js",

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -126,6 +126,11 @@ describe('loadConfig', () => {
     const cfg = loadConfig({})
     assert.throws(() => { cfg.port = 1234 }, TypeError)
   })
+
+  it('binds loopback by default and honors TAMP_HOST', () => {
+    assert.equal(loadConfig({}).host, '127.0.0.1')
+    assert.equal(loadConfig({ TAMP_HOST: '0.0.0.0' }).host, '0.0.0.0')
+  })
 })
 
 describe('loadConfigFile', () => {


### PR DESCRIPTION
Fifth `/loop` sweep — audited the main request handler and the OpenAI Responses/Codex path. One serious finding worth shipping now; the rest clean.

## [P2 security] Proxy binds 0.0.0.0, not localhost
```js
server.listen(config.port, () => { ... })   // index.js:418 AND bin/tamp.js:532
```
No host arg → binds the unspecified address (all interfaces), even though every doc, README, and the startup log say `localhost:7778`. There is no `host` in config. **Every prior audit in this sweep treated 'binds localhost' as the mitigating factor** for the disk cache, /health stats, and forwarded credentials — it wasn't true.

**Impact**: tamp forwards the caller's API key to the upstream (Anthropic / OpenAI / ChatGPT). On any LAN, shared, or multi-homed host, a peer sends `POST /v1/messages` to `http://<your-ip>:7778/` and uses tamp as an **authenticated relay on your key**, and reads usage/cost from `GET /health`. The sidecar already binds `127.0.0.1` correctly; the main proxy didn't.

**Fix**: new `config.host`, defaults to `127.0.0.1`, passed to both `listen()` sites. `TAMP_HOST=0.0.0.0` opts back into broad binding for container users. Verified via `server.address()` that it now binds loopback. Startup log prints the real host. Regression test added.

## Also audited, clean
- `/health`, `/health?text`, `/caveman-help` expose only version, stage names, session counters, static classifier regexes, and rule samples — no secrets/env/paths/config.
- `x-tamp-target` dispatch hint is validated with `provider.match()` before use — can't force a mismatched extractor.
- OpenAI Responses extract/apply: only targets `function_call_output.output` when already a string; writes string back; indices correct; never touches model-authored `input_text`.
- Compress-path errors fall back to the raw body with encoding intact; decompression bounded.

## P3s (flagged, not fixed)
- `resolveOpenAIUpstream` hardcodes `https://chatgpt.com`, ignoring the passed `base` → `config.chatgptUpstream` (`TAMP_UPSTREAM_CHATGPT`) is dead config.
- The async request handler could turn a pre-`try` throw into an unhandled rejection; attacker-reachable paths are wrapped, so theoretical.
- (The pipe-abort crash it also flagged is already fixed in open PR #23.)

## Tests
626 pass / 0 fail, smoke green. Bumps 0.8.11 → 0.8.15.